### PR TITLE
Allow diactrics characters in textExpander

### DIFF
--- a/src/presageHandler.js
+++ b/src/presageHandler.js
@@ -465,6 +465,10 @@ class PresageHandler {
     // Check if prediction should be performed
     const doPrediction = this.checkDoPrediction(lastWord, endsWithSpace);
 
+    // Lower case is somehow broken in libPresage
+    // Let's do conversion in JS
+    predictionInput = predictionInput.toLowerCase();
+
     // Return an object with the processed input string, last word and the flags for auto-capitalization and prediction
     return { predictionInput, lastWord, doPrediction, doCapitalize };
   }

--- a/src/textExpander.js
+++ b/src/textExpander.js
@@ -172,7 +172,7 @@ class TextExpander {
         type: "input",
         id: newNode ? this.addNewShortcutIDs[0] : getUniqueID(),
         class: "input",
-        pattern: "(?:[A-Za-z])*(?:[0-9])?(?:[A-Za-z])*(?:[0-9])?(?:[A-Za-z])*",
+        pattern: "[\\p{L}\\p{M}]*",
         maxLength: 32,
         value: key,
         rows: "",
@@ -259,7 +259,7 @@ class TextExpander {
         isValid = false;
         errMsgStr =
           index === 0
-            ? "Please use only letters and numbers (two or less digits), no white space or special characters are allowed, between 1-32 characters."
+            ? "Please use only letters, no numbers, white space or special characters are allowed, between 1-32 characters."
             : "Shortcut text cannot be empty.";
       }
       this.setInputState(element, errMsgStr, isValid);

--- a/tests/presageHandler.test.js
+++ b/tests/presageHandler.test.js
@@ -41,7 +41,9 @@ describe("bugs", () => {
       mod.PresageCallback.predictions = [""];
 
       testContext.ph.runPrediction("L'agglo", "", lang);
-      const expectedPastStream = lang === "fr" ? "L agglo" : "L'agglo";
+      const expectedPastStream = (
+        lang === "fr" ? "L agglo" : "L'agglo"
+      ).toLocaleLowerCase();
       expect(testContext.ph.libPresageCallback[lang].pastStream).toBe(
         expectedPastStream
       );


### PR DESCRIPTION
and disallow numbers (support for numbers was broken, so ban them).