### PR TITLE
Fix lint warnings and improve type safety

### DIFF
--- a/src/background/LanguageDetector.ts
+++ b/src/background/LanguageDetector.ts
@@ -15,10 +15,9 @@ export class LanguageDetector {
     const fallbackLanguage = (await this.settings.get(
       "fallbackLanguage",
     )) as string;
+    const globalAny = globalThis as { browser?: typeof chrome };
     const api =
-      typeof (globalThis as any).browser === "undefined"
-        ? chrome
-        : (globalThis as any).browser;
+      typeof globalAny.browser === "undefined" ? chrome : globalAny.browser;
     const result = await api.i18n.detectLanguage(text);
     let detectedLanguage: string | null = null;
     let maxPercentage = -1;

--- a/src/background/Migration.ts
+++ b/src/background/Migration.ts
@@ -23,7 +23,7 @@ export async function migrateToLocalStore(lastVersion?: string): Promise<void> {
     }) <= 0;
 
   if (migrateStore) {
-    chrome.storage.sync.get(null, (result: { [key: string]: any }) => {
+    chrome.storage.sync.get(null, (result: { [key: string]: unknown }) => {
       chrome.storage.local.set(result);
       chrome.storage.local.set({ lastVersion: currentVersion });
     });

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -314,7 +314,7 @@ function onCommand(command: string) {
 async function handleContentScriptPredictReq(
   request: ContentScriptPredictRequestMessage,
   sender: chrome.runtime.MessageSender,
-  sendResponse: (response?: any) => void,
+  sendResponse: (response?: unknown) => void,
   backgroundServiceWorker: BackgroundServiceWorker,
 ) {
   try {
@@ -363,7 +363,7 @@ async function handleContentScriptPredictReq(
 function handleOptionsPageConfigChange(
   request: OptionsPageConfigChangeMessage,
   sender: chrome.runtime.MessageSender,
-  sendResponse: (response?: any) => void,
+  sendResponse: (response?: unknown) => void,
   backgroundServiceWorker: BackgroundServiceWorker,
 ) {
   backgroundServiceWorker.updatePresageConfig();
@@ -372,7 +372,7 @@ function handleOptionsPageConfigChange(
 async function handleContentScriptGetConfig(
   request: ContentScriptGetConfigMessage,
   sender: chrome.runtime.MessageSender,
-  sendResponse: (response?: any) => void,
+  sendResponse: (response?: unknown) => void,
   backgroundServiceWorker: BackgroundServiceWorker,
 ) {
   try {
@@ -393,7 +393,7 @@ async function handleContentScriptGetConfig(
 function onMessage(
   request: Message,
   sender: chrome.runtime.MessageSender,
-  sendResponse: (response?: any) => void,
+  sendResponse: (response?: unknown) => void,
 ): boolean {
   const backgroundServiceWorker = new BackgroundServiceWorker();
   checkLastError();

--- a/src/content-script/TributeManager.ts
+++ b/src/content-script/TributeManager.ts
@@ -9,11 +9,16 @@ import {
   ForceReplaceType,
 } from "../shared/messageTypes";
 
+interface TributeItem {
+  original: { value: string };
+  string: string;
+}
+
 interface TributeEntry {
   tribute: Tribute;
   elem: Element;
   done?: (
-    results: any[],
+    results: unknown[],
     forceReplace: ForceReplaceType | null,
     menuHeader?: string,
   ) => void;
@@ -161,7 +166,7 @@ export class TributeManager {
     const tribueValuesFn = (
       _trigger: string, // text typed so far - not used directly here, context.text is used
       done: (
-        results: any[],
+        results: unknown[],
         forceReplace: ForceReplaceType | null,
         menuHeader?: string,
       ) => void,
@@ -204,9 +209,9 @@ export class TributeManager {
       containerClass: "tribute-container",
       itemClass: "",
       // @ts-expect-error ignore Tribute errors
-      selectTemplate: (item: any) => item.original.value,
+      selectTemplate: (item: TributeItem) => item.original.value,
       // @ts-expect-error ignore Tribute errors
-      menuItemTemplate: (item) => item.string,
+      menuItemTemplate: (item: TributeItem) => item.string,
       noMatchTemplate: undefined,
       // @ts-expect-error ignore Tribute errors
       menuContainer: document.body,

--- a/src/content-script/content_script.ts
+++ b/src/content-script/content_script.ts
@@ -323,7 +323,7 @@ class FluentTyper {
   messageHandler(
     message: Message,
     sender?: chrome.runtime.MessageSender,
-    sendResponse?: (response: any) => void,
+    sendResponse?: (response: unknown) => void,
   ): void {
     checkLastError();
     let sendStatusMsg = false;
@@ -427,16 +427,18 @@ class FluentTyper {
       command: CMD_CONTENT_SCRIPT_GET_CONFIG,
       context: {},
     };
-    chrome.runtime.sendMessage(msg, (response: any) => {
+    chrome.runtime.sendMessage(msg, (response: unknown) => {
       checkLastError();
-      this.messageHandler(response);
+      this.messageHandler(response as Message);
     });
   }
 
   /**
    * Applies custom theme colors by injecting CSS variables.
    */
-  private applyTheme(themeSettings: any): void {
+  private applyTheme(
+    themeSettings: NonNullable<SetConfigContext["themeConfig"]>,
+  ): void {
     console.log(
       "FluentTyper: Applying theme settings to content script:",
       themeSettings,

--- a/tests/BackgroundServiceWorker.test.ts
+++ b/tests/BackgroundServiceWorker.test.ts
@@ -17,7 +17,7 @@ const mockChrome = {
   },
   storage: {
     local: {
-      get: jest.fn((key: string, callback: (result: any) => void) => {
+      get: jest.fn((key: string, callback: (result: unknown) => void) => {
         if (typeof key === "string") {
           callback({});
         } else {
@@ -27,7 +27,7 @@ const mockChrome = {
       set: jest.fn(),
     },
     sync: {
-      get: jest.fn((key: any, callback: (result: any) => void) => {
+      get: jest.fn((key: unknown, callback: (result: unknown) => void) => {
         callback({});
       }),
       set: jest.fn(),
@@ -37,7 +37,7 @@ const mockChrome = {
     get: jest.fn((key: string) => key),
   },
 };
-(global as any).chrome = mockChrome;
+(global as unknown as { chrome: unknown }).chrome = mockChrome;
 
 // Define mocks using unstable_mockModule BEFORE importing the module under test
 jest.unstable_mockModule("../src/shared/settingsManager", () => ({
@@ -67,7 +67,7 @@ jest.unstable_mockModule("../src/background/TabMessenger", () => ({
 import type { BackgroundServiceWorker as BackgroundServiceWorkerType } from "../src/background/background";
 
 describe("BackgroundServiceWorker", () => {
-  let BackgroundServiceWorkerClass: any;
+  let BackgroundServiceWorkerClass: { new(): BackgroundServiceWorkerType };
   let worker: BackgroundServiceWorkerType;
 
   beforeAll(async () => {
@@ -78,7 +78,9 @@ describe("BackgroundServiceWorker", () => {
   beforeEach(() => {
     // Clear instance
     if (BackgroundServiceWorkerClass) {
-      (BackgroundServiceWorkerClass as any).instance = undefined;
+      (
+        BackgroundServiceWorkerClass as unknown as { instance: unknown }
+      ).instance = undefined;
       worker = new BackgroundServiceWorkerClass();
     }
   });
@@ -93,7 +95,11 @@ describe("BackgroundServiceWorker", () => {
   describe("runPrediction", () => {
     it("should not send message if no predictions and no forceReplace", async () => {
       // Setup mock return
-      (worker.predictionManager.runPrediction as any).mockResolvedValue({
+      (
+        worker.predictionManager.runPrediction as jest.Mock<
+          () => Promise<unknown>
+        >
+      ).mockResolvedValue({
         predictions: [],
         forceReplace: null,
       });
@@ -115,7 +121,11 @@ describe("BackgroundServiceWorker", () => {
     });
 
     it("should send message if predictions exist", async () => {
-      (worker.predictionManager.runPrediction as any).mockResolvedValue({
+      (
+        worker.predictionManager.runPrediction as jest.Mock<
+          () => Promise<unknown>
+        >
+      ).mockResolvedValue({
         predictions: ["tested"],
         forceReplace: null,
       });

--- a/tests/e2e/puppeteer-extension.test.ts
+++ b/tests/e2e/puppeteer-extension.test.ts
@@ -194,7 +194,9 @@ describe("Chrome Extension E2E Test", () => {
       await textarea!.click();
       // Ensure textarea is focused and clear
       await page.evaluate(
-        () => ((document.querySelector("#test-textarea") as any).value = ""),
+        () =>
+          (document.querySelector("#test-textarea") as HTMLTextAreaElement)
+            .value = "",
       );
       await textarea!.type(testData.input);
       // Wait for predictions to update after typing
@@ -217,7 +219,9 @@ describe("Chrome Extension E2E Test", () => {
 
       // Cleanup for next iteration
       await page.evaluate(
-        () => ((document.querySelector("#test-textarea") as any).value = ""),
+        () =>
+          (document.querySelector("#test-textarea") as HTMLTextAreaElement)
+            .value = "",
       );
       // Wait for predictions to disappear
       // Note: Tribute might not remove the container, just hide it.

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -16,7 +16,7 @@ const mockChrome = {
   },
   storage: {
     local: {
-      get: jest.fn((key: string, callback: (result: any) => void) => {
+      get: jest.fn((key: string, callback: (result: unknown) => void) => {
         if (typeof key === "string") {
           callback({});
         } else {
@@ -30,4 +30,4 @@ const mockChrome = {
     get: jest.fn((key: string) => key),
   },
 };
-(global as any).chrome = mockChrome;
+(global as unknown as { chrome: unknown }).chrome = mockChrome;


### PR DESCRIPTION
Fixes all \`npm run check\` warnings by replacing \`any\` with \`unknown\` or specific types. Also updates tests to be more type-safe.