### PR TITLE
Add CKEditor 5 field to E2E test matrix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "luxon": "^3.7.2"
       },
       "devDependencies": {
+        "@ckeditor/ckeditor5-build-classic": "^41.4.2",
         "@eslint/js": "^10.0.1",
         "@types/chrome": "^0.1.37",
         "@types/dom-navigation": "^1.0.7",
@@ -557,6 +558,811 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-41.4.2.tgz",
+      "integrity": "sha512-yXVVEy+lEmyvYwTxn76Ff53fK/qJphf9stoBF4kFKKK/Tfi59EMog2Ctk3iIkLLyt74KmxzvuCXZwE00wDqfLA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-41.4.2.tgz",
+      "integrity": "sha512-Ukit63jHiAuLyfESdLSc6ya12xKJxDP83krZFiMY5bfXssg0z39CGuHOZlwaI9r7bBjWWMGJJeaC/9i/6L9y7g==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-41.4.2.tgz",
+      "integrity": "sha512-+Y+M9/JRX3xSHX/E5zFwzuKPzEeeuL61wcig1DuEz7GvK5sRLJcbdVQmiJnfDh3iOcf/ob1nahNgHAEoCno0Dw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-41.4.2.tgz",
+      "integrity": "sha512-tkEKd3pmDO8QWm243FRDRUv5COayXYZJpMFUL6blw3m6IXb4ujcXKn61A+UwUO+kM0NGTuepHZJkFSuV1/90sw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-balloon/-/ckeditor5-build-balloon-41.4.2.tgz",
+      "integrity": "sha512-4FLvd2OV4UgPva0/+xHT4ZuEzKLxB9M6D04/G0YFFwvbPiy71zH0iEMj132Wd0fdEJ0fwjF1HfDzhNgI9BPhPA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-balloon-block/-/ckeditor5-build-balloon-block-41.4.2.tgz",
+      "integrity": "sha512-p2pXJcS0hNuDZXyMi0frSwLZBm1hGGEEajJtAvKdg+pKZvvrIabQzvjtrkUf5P6Lbhl/z1/v2h0pBa76025Q5Q==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-classic": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-41.4.2.tgz",
+      "integrity": "sha512-fdsxmEPdNdo/usXyYMS2cN/E9KcQIrtmImUYDI+jEs6yzmSgI8By01n+enkKgVxu+2t+g+ctjQwrCpiyWIHTAQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-decoupled-document/-/ckeditor5-build-decoupled-document-41.4.2.tgz",
+      "integrity": "sha512-YIjcJc9flghFsA5gZaL5oIf6TxLJxUZpXgWYa9l5C68enm36bsDycgJWGGbexHK2HOR9AnBr6ThUBQJkn3StTg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-inline/-/ckeditor5-build-inline-41.4.2.tgz",
+      "integrity": "sha512-h57jjFm0cSOFGSTA2MbvhSXMFxUbPZqwIeA9S0bfUNcGrnm84YaerX8ev8ZP2iMLOckPOcjBiC/70Sp0SvGwxg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-multi-root/-/ckeditor5-build-multi-root-41.4.2.tgz",
+      "integrity": "sha512-Hou3cHuzx2YR6cfbTYYgk2cSBkudCfPru471KxsXUtzw+B7KuHLm3LtnLJNpScF2WoGaOoaFzB9D2PkzlhF5hA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-41.4.2.tgz",
+      "integrity": "sha512-u6HVTW7O+YSeeCZ+plg78aW74B2G+E7uKy5YQxvB99uCXGWmYy57D2maaEkPI87ZwZD3VlRnvAalaAdngc4M1g==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "blurhash": "2.0.5",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-41.4.2.tgz",
+      "integrity": "sha512-QB3igdZOBI+I8q6eTA5+q27VQrj3Nu7PctNKRehwMC/Z6URboTnntqtkZ3inAZEbWcoLTN2tpDthlufUbQ+cfA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-41.4.2.tgz",
+      "integrity": "sha512-rgDrpEonA2AchfvgYaeb/olMk/HYxUK4B8XPqs+nJxLmBraTv2lANsgsMbwsqAIiRjT9MknmJdX+CEbqljgL/w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-core": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-41.4.2.tgz",
+      "integrity": "sha512-kCIJjviiMNIMBMx7XFXFp1IeTELQKv7xyPJiVFDyUftIfthf9uWty72ipZ3BBNBGBkaoTiSzDZ507EsX6czuIQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-41.4.2.tgz",
+      "integrity": "sha512-HJJ3Z4R4mCazV2cz+s8bI00ci3/KyIa+fXodBN1+kg3PldX471zSj+DtyFsZyKnUcpUTVygjPEaHKBDpxtUhjQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-41.4.2.tgz",
+      "integrity": "sha512-BVf4ipZz36eCTDFiQ8hqN+oBmuvZPzCmNDDjCYuHNGCKGLaIo1Yzi09fHPUWDw1U+en6Cgnwc2HSWgwf7zC7aA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-41.4.2.tgz",
+      "integrity": "sha512-25JqIzNYvCqQ6f02YY+a8A8xtjClzI0YCio0JGoRG3JHJXzYsQbTPsiokuE1BCwMCu3gYoFz8eKJYt2selLsCw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-41.4.2.tgz",
+      "integrity": "sha512-1UCvk76v2+NDfHfTo3Qg0EJYpddgSC/i66jY3NnQUFt1zt68rAzm/kFOVYjTD/QDn6pyiMAIUeMlKFkswF+upg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-41.4.2.tgz",
+      "integrity": "sha512-8AyMumy90nY49reQlHuCgSJFSaym4emCVF6vAAqd71FHtmgtfS9w3xMqXAk6QbgMjfy46cwind0JITZfBfKqLg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.4.2.tgz",
+      "integrity": "sha512-4AgXdvYr6tGzEqwAHVRl+LA8nPRER7vQthVBuT4g1FEkRB6w9kgRsPM2JfsGekoGd8GU0WnMaz8kAcL4C2urYg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-41.4.2.tgz",
+      "integrity": "sha512-pghHa+DKya6788nTiU1ZItKmAgjf+up4Rqe5GOkxKB7vJc189KSBJYc5foov65nM831rXcWgTk4jybK+JGHmjQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-41.4.2.tgz",
+      "integrity": "sha512-woMv9/BxkDjG5xsS/OyaxW9tWTuiG6wZWWcYxVJq8FOW2NL68CKQLmyoQ1rdv/2Gw4UPUXTtB+1uGVmQDMXDsQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-41.4.2.tgz",
+      "integrity": "sha512-nGb36jNJO6YAU35piKabey9B13xw6TnmL5VySS2dEqSt/DTy7RdY5z2K7CU/NGuIGe/bPBZgU1J0dQkRr2F3hA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.4.2.tgz",
+      "integrity": "sha512-+4JqfbnMrB9Si2gAKKCRZTY1hixlk11mY8+PA+32UezyCq/myoAlVGT8ytCr3rywe58nbkGGAv2QbVo6fy8zoQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paragraph": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-41.4.2.tgz",
+      "integrity": "sha512-tOsD40Fcqli5zkH/68WhcqYU8BL4qb8J5xGuk1xmBokz3W0LzebWW0GXmFk5PmWv+fg0dOXfSo8uMzb5ni+CuQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-41.4.2.tgz",
+      "integrity": "sha512-jby5YQ2QowGdDCshPq5Ej11wTFcBZP2dYhQTu6fRZRc+mdihKCILxh0rwBgBOCCf+buflx8RYp/WKd76Kcuq5g==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.4.2.tgz",
+      "integrity": "sha512-wDn1UUaKHcrscmTYj2PwCFbj9FOXFfhk4JbCepyGFQt31YyaOKBzAyZaJQ7E38wJq7a4afac3MwUDk+j1X5FDw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-41.4.2.tgz",
+      "integrity": "sha512-dXP+uNl+jkfrSIqMNai2yakR/3JqJ9g0M9WwwnV5vzbEOKD4YKP5+ixvqKb39dwLCLZ4mGpJaX+rjNXBExjSIw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-41.4.2.tgz",
+      "integrity": "sha512-wvRbDXJN8PmaWyB0H487DjvdH2ayMyN52+WLkZlVbhX9ICb1sf5XnLz4v/wXeQ4W8JbWdsg2FZIDDQDeXjvyJw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "color-convert": "2.0.1",
+        "color-parse": "1.4.2",
+        "lodash-es": "4.17.21",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-41.4.2.tgz",
+      "integrity": "sha512-VgLr2eLVggyhDqa7H8JUxpnOLTZ0R/YuDZ6ENVUumd9q4VrpNs94ZK0Y/Shp7UmuHQ/sTth+PWTsi+t5KwYqeQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -1753,6 +2559,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -2784,10 +3600,42 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      }
+    },
+    "node_modules/acorn-globals/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2818,6 +3666,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -3252,6 +4110,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/blurhash": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
+      "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
@@ -3277,6 +4142,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -3505,6 +4377,78 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3572,6 +4516,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-parse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
+      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0"
+      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -3702,6 +4656,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -3865,6 +4826,30 @@
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6695,6 +7680,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6779,6 +7771,19 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7481,6 +8486,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -7607,6 +8625,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -7656,6 +8681,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -8715,6 +9747,324 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/turndown": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-6.0.0.tgz",
+      "integrity": "sha512-UVJBhSyRHCpNKtQ00mNWlYUM/i+tcipkb++F0PrOpt0L7EhNd0AX9mWEpL2dRFBu7LWXMp4HgAMA4OeKKnN7og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsdom": "^16.2.0"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/turndown/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/turndown/node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/turndown/node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/turndown/node_modules/data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/turndown/node_modules/form-data": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/turndown/node_modules/html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/turndown/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/turndown/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/turndown/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/turndown/node_modules/jsdom": {
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.5",
+        "acorn": "^8.2.4",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.5.0",
+        "ws": "^7.4.6",
+        "xml-name-validator": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/turndown/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/turndown/node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/turndown/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/turndown/node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/turndown/node_modules/w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/turndown/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
+    "node_modules/turndown/node_modules/whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "node_modules/turndown/node_modules/whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/turndown/node_modules/whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/turndown/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/turndown/node_modules/xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8817,6 +10167,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -8893,6 +10253,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -8906,6 +10277,24 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vanilla-colorful": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
+      "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-process-hrtime": "^1.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/bartekplus/FluentTyper#readme",
   "devDependencies": {
+    "@ckeditor/ckeditor5-build-classic": "^41.4.2",
     "@eslint/js": "^10.0.1",
     "@types/chrome": "^0.1.37",
     "@types/dom-navigation": "^1.0.7",

--- a/tests/e2e/puppeteer-extension.test.ts
+++ b/tests/e2e/puppeteer-extension.test.ts
@@ -13,6 +13,13 @@ import { SUPPORTED_PREDICTION_LANGUAGE_KEYS } from "../../src/shared/lang";
 const EXTENSION_PATH = path.resolve(__dirname, "../../build/");
 const TEST_PAGE_PATH = path.resolve(__dirname, "test-page.html");
 const SETTINGS_PREFIX = "store.settings.";
+const CKEDITOR_SELECTOR = ".ck-editor__editable";
+const TEST_INPUT_SELECTORS = [
+  "#test-textarea",
+  "#test-input",
+  "#test-contenteditable",
+  CKEDITOR_SELECTOR,
+] as const;
 
 async function setSetting(
   worker: WebWorker,
@@ -113,11 +120,56 @@ async function openOptionsPage(browser: Browser, worker: WebWorker) {
   return optionsPage;
 }
 
-async function gotoTestPage(page: Page) {
+function shouldEnableCkEditor(selector: string) {
+  return selector === CKEDITOR_SELECTOR;
+}
+
+async function gotoTestPage(
+  page: Page,
+  options: { enableCkEditor?: boolean } = {},
+) {
   const testName = expect.getState().currentTestName || "Unknown Test";
-  await page.goto(
-    `file://${TEST_PAGE_PATH}?testName=${encodeURIComponent(testName)}`,
-  );
+  const params = new URLSearchParams({ testName });
+  if (options.enableCkEditor) {
+    params.set("enableCkEditor", "1");
+  }
+  await page.goto(`file://${TEST_PAGE_PATH}?${params.toString()}`);
+}
+
+async function waitForInputReady(page: Page, selector: string) {
+  if (selector === CKEDITOR_SELECTOR) {
+    await page.waitForFunction(
+      () =>
+        Boolean(
+          (
+            window as typeof window & {
+              __testCkEditorReady?: boolean;
+              __testCkEditorError?: string | null;
+            }
+          ).__testCkEditorReady ||
+            (
+              window as typeof window & {
+                __testCkEditorError?: string | null;
+              }
+            ).__testCkEditorError,
+        ),
+      { timeout: 10000 },
+    );
+
+    const ckEditorError = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __testCkEditorError?: string | null;
+          }
+        ).__testCkEditorError,
+    );
+    if (ckEditorError) {
+      throw new Error(`CKEditor failed to initialize: ${ckEditorError}`);
+    }
+  }
+
+  await page.waitForSelector(selector, { timeout: 10000 });
 }
 
 describe("Chrome Extension E2E Test", () => {
@@ -131,6 +183,7 @@ describe("Chrome Extension E2E Test", () => {
       args: [
         `--disable-extensions-except=${EXTENSION_PATH}`,
         `--load-extension=${EXTENSION_PATH}`,
+        "--allow-file-access-from-files",
       ],
       defaultViewport: null,
     });
@@ -187,12 +240,23 @@ describe("Chrome Extension E2E Test", () => {
     expect(popupPage).toBeDefined();
   }, 2000);
 
-  test.each([["#test-textarea"], ["#test-input"], ["#test-contenteditable"]])(
+  test("CKEditor 5 input initializes on test page", async () => {
+    await gotoTestPage(page, { enableCkEditor: true });
+    page.bringToFront();
+    await waitForInputReady(page, CKEDITOR_SELECTOR);
+
+    const ckEditorElement = await page.$(CKEDITOR_SELECTOR);
+    expect(ckEditorElement).toBeTruthy();
+  }, 15000);
+
+  test.each(TEST_INPUT_SELECTORS)(
     "Prediction popup appears in %s when typing and prediction is inserted on click",
     async (selector) => {
-      await gotoTestPage(page);
+      await gotoTestPage(page, {
+        enableCkEditor: shouldEnableCkEditor(selector),
+      });
       page.bringToFront();
-      await page.waitForSelector(selector);
+      await waitForInputReady(page, selector);
       const element = await page.$(selector);
       await element!.type("h"); // Type a few letters
       // Wait for prediction popup
@@ -220,15 +284,17 @@ describe("Chrome Extension E2E Test", () => {
       // Inserted text should match what was shown in the suggestion
       expect(elementText).toBe(firstLiText?.toLowerCase());
     },
-    1500,
+    30000,
   );
 
-  test.each([["#test-textarea"], ["#test-input"], ["#test-contenteditable"]])(
+  test.each(TEST_INPUT_SELECTORS)(
     "Prediction popup appears in %s when typing and prediction is inserted on TAB",
     async (selector) => {
-      await gotoTestPage(page);
+      await gotoTestPage(page, {
+        enableCkEditor: shouldEnableCkEditor(selector),
+      });
       page.bringToFront();
-      await page.waitForSelector(selector);
+      await waitForInputReady(page, selector);
       const element = await page.$(selector);
       await element!.type("w"); // Type a few letters
       // Wait for prediction popup
@@ -263,7 +329,7 @@ describe("Chrome Extension E2E Test", () => {
       // Inserted text should match the first suggestion
       expect(elementText).toBe(firstLiText?.toLowerCase());
     },
-    4000,
+    30000,
   );
 
   test("Cursor movement cancels missing space auto-insertion", async () => {
@@ -310,10 +376,12 @@ describe("Chrome Extension E2E Test", () => {
     expect(textAreaText).toBe(wordPart + "x\xa0");
   }, 1500);
 
-  test.each([["#test-textarea"], ["#test-input"], ["#test-contenteditable"]])(
+  test.each(TEST_INPUT_SELECTORS)(
     "Inline suggestion prediction is inserted on TAB in %s",
     async (selector) => {
-      await gotoTestPage(page);
+      await gotoTestPage(page, {
+        enableCkEditor: shouldEnableCkEditor(selector),
+      });
       page.bringToFront();
 
       await setSetting(worker!, KEY_INLINE_SUGGESTION, true);
@@ -322,7 +390,7 @@ describe("Chrome Extension E2E Test", () => {
       );
       await new Promise((r) => setTimeout(r, 50));
 
-      await page.waitForSelector(selector);
+      await waitForInputReady(page, selector);
       const element = await page.$(selector);
       await element!.type("w");
 
@@ -353,7 +421,7 @@ describe("Chrome Extension E2E Test", () => {
       );
       await new Promise((r) => setTimeout(r, 50));
     },
-    3000,
+    30000,
   );
 
   test("Enabled languages restrict popup language list", async () => {
@@ -706,10 +774,12 @@ describe("Chrome Extension E2E Test", () => {
     await new Promise((r) => setTimeout(r, 50));
   }, 12000);
 
-  test.each([["#test-textarea"], ["#test-input"], ["#test-contenteditable"]])(
+  test.each(TEST_INPUT_SELECTORS)(
     "Prediction popup can be closed via Escape key in %s",
     async (selector) => {
-      await gotoTestPage(page);
+      await gotoTestPage(page, {
+        enableCkEditor: shouldEnableCkEditor(selector),
+      });
       page.bringToFront();
 
       await setSetting(worker!, KEY_LANGUAGE, "en_US");
@@ -718,7 +788,7 @@ describe("Chrome Extension E2E Test", () => {
       );
       await new Promise((r) => setTimeout(r, 100));
 
-      await page.waitForSelector(selector);
+      await waitForInputReady(page, selector);
       const element = await page.$(selector);
 
       await element!.type("h"); // Trigger popup
@@ -739,13 +809,15 @@ describe("Chrome Extension E2E Test", () => {
         { timeout: 500 },
       );
     },
-    3000,
+    30000,
   );
 
-  test.each([["#test-textarea"], ["#test-input"], ["#test-contenteditable"]])(
+  test.each(TEST_INPUT_SELECTORS)(
     "Text expansion works correctly in %s",
     async (selector) => {
-      await gotoTestPage(page);
+      await gotoTestPage(page, {
+        enableCkEditor: shouldEnableCkEditor(selector),
+      });
       page.bringToFront();
 
       await setSetting(worker!, KEY_ENABLED_LANGUAGES, ["textExpander"]);
@@ -755,7 +827,7 @@ describe("Chrome Extension E2E Test", () => {
       );
       await new Promise((r) => setTimeout(r, 100));
 
-      await page.waitForSelector(selector);
+      await waitForInputReady(page, selector);
       const element = await page.$(selector);
       await element!.type("asap"); // Trigger text expansion
 
@@ -794,10 +866,10 @@ describe("Chrome Extension E2E Test", () => {
       );
       await new Promise((r) => setTimeout(r, 100));
     },
-    3000,
+    30000,
   );
 
-  test.each([["#test-textarea"], ["#test-input"], ["#test-contenteditable"]])(
+  test.each(TEST_INPUT_SELECTORS)(
     "KEY_MIN_WORD_LENGTH_TO_PREDICT set to 0 predicts immediately after space in %s",
     async (selector) => {
       // Set settings BEFORE creating the page so content script initializes correctly
@@ -810,10 +882,12 @@ describe("Chrome Extension E2E Test", () => {
       );
       await notifyConfigChange(browser, worker!);
 
-      await gotoTestPage(page);
+      await gotoTestPage(page, {
+        enableCkEditor: shouldEnableCkEditor(selector),
+      });
       page.bringToFront();
 
-      await page.waitForSelector(selector);
+      await waitForInputReady(page, selector);
       const element = await page.$(selector);
 
       // Step 1: Type "a" and confirm predictions appear
@@ -834,10 +908,10 @@ describe("Chrome Extension E2E Test", () => {
       await setSettingAndWait(worker!, KEY_MIN_WORD_LENGTH_TO_PREDICT, 1);
       await notifyConfigChange(browser, worker!);
     },
-    5000,
+    30000,
   );
 
-  test.each([["#test-textarea"], ["#test-input"], ["#test-contenteditable"]])(
+  test.each(TEST_INPUT_SELECTORS)(
     "KEY_MIN_WORD_LENGTH_TO_PREDICT set to -1 does not predict automatically in %s",
     async (selector) => {
       // Reset and set settings BEFORE creating the page
@@ -849,10 +923,12 @@ describe("Chrome Extension E2E Test", () => {
         SUPPORTED_PREDICTION_LANGUAGE_KEYS,
       );
       await notifyConfigChange(browser, worker!);
-      await gotoTestPage(page);
+      await gotoTestPage(page, {
+        enableCkEditor: shouldEnableCkEditor(selector),
+      });
       page.bringToFront();
 
-      await page.waitForSelector(selector);
+      await waitForInputReady(page, selector);
       const element = await page.$(selector);
 
       // Type something
@@ -870,6 +946,6 @@ describe("Chrome Extension E2E Test", () => {
       await setSettingAndWait(worker!, KEY_MIN_WORD_LENGTH_TO_PREDICT, 1);
       await notifyConfigChange(browser, worker!);
     },
-    3000,
+    30000,
   );
 });

--- a/tests/e2e/test-page.html
+++ b/tests/e2e/test-page.html
@@ -89,6 +89,10 @@
         min-height: 80px;
         cursor: text;
       }
+
+      .ck-editor__editable {
+        min-height: 80px;
+      }
     </style>
   </head>
 
@@ -108,12 +112,57 @@
         <label for="test-contenteditable">Content Editable Div</label>
         <div contenteditable="true" id="test-contenteditable"></div>
       </div>
+      <div class="input-group" id="test-ckeditor-group">
+        <label for="test-ckeditor">CKEditor 5</label>
+        <textarea id="test-ckeditor" rows="4"></textarea>
+      </div>
     </div>
     <script>
       const params = new URLSearchParams(window.location.search);
       const testName = params.get("testName");
+      const enableCkEditor = params.get("enableCkEditor") === "1";
       if (testName) {
         document.getElementById("test-name").textContent = testName;
+      }
+
+      window.__testCkEditorReady = false;
+      window.__testCkEditorError = null;
+      const ckEditorGroup = document.getElementById("test-ckeditor-group");
+      if (!enableCkEditor) {
+        ckEditorGroup.style.display = "none";
+      } else {
+        const script = document.createElement("script");
+        script.src =
+          "../../node_modules/@ckeditor/ckeditor5-build-classic/build/ckeditor.js";
+        script.onload = () => {
+          if (!window.ClassicEditor) {
+            window.__testCkEditorError = "ClassicEditor global is unavailable";
+            return;
+          }
+
+          window.ClassicEditor.create(
+            document.getElementById("test-ckeditor"),
+            {
+              licenseKey: "GPL",
+            },
+          )
+            .then((editor) => {
+              editor.ui.view.editable.element.id = "test-ckeditor-editable";
+              window.__testCkEditorReady = true;
+              window.__testCkEditor = editor;
+            })
+            .catch((error) => {
+              window.__testCkEditorError = error?.message || String(error);
+              console.error(
+                "CKEditor initialization failed in e2e test page.",
+                error,
+              );
+            });
+        };
+        script.onerror = () => {
+          window.__testCkEditorError = "Failed to load CKEditor script";
+        };
+        document.head.appendChild(script);
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add a 4th input on `tests/e2e/test-page.html` powered by CKEditor 5
- load CKEditor locally from `node_modules` for deterministic E2E runs
- make CKEditor loading opt-in via `enableCkEditor=1` query param so non-CKEditor cases stay fast
- extend selector-based E2E coverage to include CKEditor editable (`.ck-editor__editable`)
- add an explicit sanity test verifying CKEditor input initialization

## Implementation details
- introduced `TEST_INPUT_SELECTORS` + `waitForInputReady()` to unify readiness handling across input types
- added CKEditor error surfacing in the test page via `window.__testCkEditorError`
- enabled Chromium file access for local file-based loading (`--allow-file-access-from-files`)
- added dev dependency: `@ckeditor/ckeditor5-build-classic`

## Validation
- `npm run check`
- `npm run test:e2e -- --runInBand`

## Notes
This addresses CKEditor 5 integration coverage requested from bug reports and ensures the existing E2E flow now exercises rich-text editor input as part of the main matrix.