### PR TITLE
fix: correct Portuguese short-code auto-detect mapping

### DIFF
--- a/src/shared/lang.ts
+++ b/src/shared/lang.ts
@@ -50,7 +50,7 @@ export const SUPPORTED_LANGUAGES_SHORT_CODE: Record<string, string> = {
   sv: "sv_SE",
   de: "de_DE",
   pl: "pl_PL",
-  pr: "pt_BR",
+  pt: "pt_BR",
 };
 
 export const DEFAULT_SEPERATOR_CHARS_REGEX: RegExp = RegExp(


### PR DESCRIPTION
## Summary
- fix prediction language short-code mapping for Portuguese
- replace incorrect `pr` key with `pt` in `SUPPORTED_LANGUAGES_SHORT_CODE`

## Testing
- not run (single constant mapping change)