### PR TITLE
Fix detached element cleanup check

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -269,5 +269,5 @@ export function isNumber(str: string): boolean {
  * Checks if the given element is part of the document tree.
  */
 export function isInDocument(element: Element): boolean {
-  return element.ownerDocument === document;
+  return document.contains(element);
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -2,6 +2,7 @@ import { jest } from "@jest/globals";
 import {
   SETTINGS_DOMAIN_BLACKLIST,
   addDomainToList,
+  isInDocument,
   isDomainOnList,
   removeDomainFromList,
 } from "../src/shared/utils";
@@ -87,5 +88,18 @@ describe("shared utils domain list handling", () => {
     await removeDomainFromList(settings, "localhost");
     expect(state[SETTINGS_DOMAIN_BLACKLIST]).toEqual([]);
     expect(getMock).toHaveBeenCalledWith(SETTINGS_DOMAIN_BLACKLIST);
+  });
+});
+
+describe("shared utils DOM helpers", () => {
+  test("isInDocument returns false for detached nodes and true only while attached", () => {
+    const element = document.createElement("div");
+    expect(isInDocument(element)).toBe(false);
+
+    document.body.appendChild(element);
+    expect(isInDocument(element)).toBe(true);
+
+    element.remove();
+    expect(isInDocument(element)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- fix `isInDocument` to use `document.contains(element)` instead of `ownerDocument === document`
- prevent detached elements from being treated as still attached
- add regression test for detached/attached/removed lifecycle

## Validation
- npm test -- tests/utils.test.ts