### PR TITLE
Fix settings export filename assignment

### DIFF
--- a/src/third_party/fancier-settings/settings.js
+++ b/src/third_party/fancier-settings/settings.js
@@ -301,17 +301,17 @@ window.addEventListener("DOMContentLoaded", function () {
           // Convert object to a JSON.
           const result = JSON.stringify(items);
           const blob = new Blob([result], { type: "application/json" });
+          const exportFilename = "FluentTyperSettings.json";
           const dlink = document.createElement("a");
-          dlink.download = name;
           dlink.href = window.URL.createObjectURL(blob);
-          (dlink.download = "FluentTyperSettings.json"),
-            (dlink.onclick = function () {
-              // revokeObjectURL needs a delay to work properly
-              const that = this;
-              setTimeout(function () {
-                window.URL.revokeObjectURL(that.href);
-              }, 1500);
-            });
+          dlink.download = exportFilename;
+          dlink.onclick = function () {
+            // revokeObjectURL needs a delay to work properly
+            const that = this;
+            setTimeout(function () {
+              window.URL.revokeObjectURL(that.href);
+            }, 1500);
+          };
 
           dlink.click();
           dlink.remove();


### PR DESCRIPTION
## Summary
- remove redundant `dlink.download = name` assignment in settings export flow
- assign export filename once via explicit `exportFilename` constant
- replace comma-expression assignment with clear statement-based handler setup

## Validation
- node --check src/third_party/fancier-settings/settings.js