### PR TITLE
Improve docs structure and reporting templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Report a reproducible bug in FluentTyper
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill in the details below so we can reproduce and fix it.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly and briefly.
+      placeholder: FluentTyper suggestions disappear when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal set of steps.
+      placeholder: |
+        1. Open ...
+        2. Type ...
+        3. Press ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: Suggestions should stay visible and selectable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Suggestions disappear after the first keystroke.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      options:
+        - Chrome
+        - Firefox
+        - Edge
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: fluenttyper_version
+    attributes:
+      label: FluentTyper version
+      description: You can usually find this in your browser extension manager.
+      placeholder: e.g. 2026.2.1
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. macOS 15.3, Windows 11, Ubuntu 24.04
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Logs, screenshots, or recordings
+      description: Drag and drop media files here if helpful.
+      placeholder: Add any extra context that might help debugging.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature ideas and feedback
+    url: https://github.com/bartekplus/FluentTyper/issues/new?template=feature_request.yml
+    about: Share product suggestions or general feedback via the feature request form.
+  - name: Report a security vulnerability
+    url: https://github.com/bartekplus/FluentTyper/security/policy
+    about: Please do not post security vulnerabilities in public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,77 @@
+name: Feature request
+description: Suggest an improvement or new capability for FluentTyper
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please share enough detail to evaluate scope and impact.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What pain point are you experiencing today?
+      placeholder: I often need to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you want FluentTyper to do.
+      placeholder: Add an option to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workaround or alternative approaches you tried.
+      placeholder: I tried...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Affected browser(s)
+      description: Select the browser where this feature matters most.
+      options:
+        - Chrome
+        - Firefox
+        - Edge
+        - All browsers
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: fluenttyper_version
+    attributes:
+      label: FluentTyper version
+      description: Optional but helpful for context.
+      placeholder: e.g. 2026.2.1
+    validations:
+      required: false
+
+  - type: textarea
+    id: mockups
+    attributes:
+      label: Mockups, examples, or references
+      description: Add screenshots, links, or examples from other tools.
+      placeholder: Link or drag files here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      placeholder: Anything else that would help evaluate this request.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing to FluentTyper
+
+Thanks for your interest in improving FluentTyper. This document is for developers and contributors.
+
+## Before You Start
+
+- Read the user docs in [README.md](README.md) to understand product behavior.
+- Check open issues before starting work: [github.com/bartekplus/FluentTyper/issues](https://github.com/bartekplus/FluentTyper/issues)
+- For bugs, use the bug report template: [issues/new/choose](https://github.com/bartekplus/FluentTyper/issues/new/choose)
+
+## Development Setup
+
+### Requirements
+
+- Node.js 24 (matches CI)
+- npm
+
+### Local Setup
+
+1. Fork the repository and clone your fork.
+2. Install dependencies:
+   ```bash
+   npm ci
+   ```
+3. Build the extension:
+   ```bash
+   npm run build
+   ```
+
+## Run Locally in a Browser
+
+Build once:
+
+```bash
+npm run build
+```
+
+Or run watch mode for iterative development:
+
+```bash
+npm run watch
+```
+
+To test a Chrome/Edge build specifically:
+
+```bash
+PLATFORM=chrome npm run watch
+```
+
+Load the unpacked extension from the `build/` directory:
+
+- Chrome/Edge: open extensions page, enable developer mode, choose "Load unpacked", select `build/`
+- Firefox: open `about:debugging`, choose "This Firefox", click "Load Temporary Add-on", select `build/manifest.json`
+
+## Quality Checks
+
+Run these before opening a pull request:
+
+```bash
+npm run check
+npm run test
+```
+
+Optional local autofix formatting and linting:
+
+```bash
+npm run lint
+```
+
+Optional end-to-end tests:
+
+```bash
+npm run test:e2e
+```
+
+## Branch and PR Workflow
+
+1. Create a branch from `master`.
+2. Keep commits focused and descriptive.
+3. Open a pull request against `master`.
+4. Ensure CI is green (tests and lint checks).
+5. Describe what changed, why, and how it was tested.
+
+## Bug Reporting Process
+
+Both users and contributors should report product bugs via GitHub issue forms:
+
+- Issue chooser: [github.com/bartekplus/FluentTyper/issues/new/choose](https://github.com/bartekplus/FluentTyper/issues/new/choose)
+- Direct bug form: [bug_report.yml](https://github.com/bartekplus/FluentTyper/issues/new?template=bug_report.yml)
+
+Include these details in every bug report:
+
+- Clear reproduction steps
+- Expected result
+- Actual result
+- Browser and OS
+- FluentTyper version
+- Screenshots or recordings (if available)
+
+## Feature Request Process
+
+Use GitHub issue forms for feature ideas and product improvements:
+
+- Issue chooser: [github.com/bartekplus/FluentTyper/issues/new/choose](https://github.com/bartekplus/FluentTyper/issues/new/choose)
+- Direct feature form: [feature_request.yml](https://github.com/bartekplus/FluentTyper/issues/new?template=feature_request.yml)
+
+Strong feature requests include:
+
+- The user problem and impact
+- A concrete proposal
+- Alternatives considered
+- Browser-specific context
+
+## Security Reporting
+
+Do not disclose vulnerabilities in public issues. Follow [SECURITY.md](SECURITY.md) for private reporting.
+
+## Documentation Contributions
+
+Documentation improvements are welcome. Keep audience separation:
+
+- `README.md`: end-user focused
+- `CONTRIBUTING.md`: developer and contribution workflow
+
+When behavior changes, update docs in the same pull request.
+
+## Dependencies
+
+FluentTyper is built with:
+
+- [Tribute](https://github.com/bartekplus/tribute)
+- [Presage](https://github.com/bartekplus/presage)
+- [Fancier Settings](https://github.com/bartekplus/fancier-settings)
+
+## License
+
+By contributing, you agree that your contributions are licensed under the [MIT License](LICENSE).
+
+## Sponsorship and Support
+
+If you want to support maintenance and development:
+
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-Support-FFDD00?logo=buymeacoffee&logoColor=000000)](https://www.buymeacoffee.com/FluentTyper)

--- a/README.md
+++ b/README.md
@@ -1,34 +1,36 @@
+![FluentTyper logo](public/icon/LogoFluentTyperWhite.jpg)
 
-![Logo](public/icon/LogoFluentTyperWhite.jpg)
+# FluentTyper
 
+Type less, do more. FluentTyper brings smart autocomplete, spell checking, and text expansion to text inputs across the web.
 
-[![Unit test](https://github.com/bartekplus/FluentTyper/actions/workflows/test.yml/badge.svg)](https://github.com/bartekplus/FluentTyper/actions/workflows/test.yml)
-[![ESLint & Prettier check](https://github.com/bartekplus/FluentTyper/actions/workflows/lintCheck.yml/badge.svg)](https://github.com/bartekplus/FluentTyper/actions/workflows/lintCheck.yml)
+[![Unit and E2E tests](https://github.com/bartekplus/FluentTyper/actions/workflows/test.yml/badge.svg)](https://github.com/bartekplus/FluentTyper/actions/workflows/test.yml)
+[![ESLint and Prettier check](https://github.com/bartekplus/FluentTyper/actions/workflows/lintCheck.yml/badge.svg)](https://github.com/bartekplus/FluentTyper/actions/workflows/lintCheck.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-Support-FFDD00?logo=buymeacoffee&logoColor=000000)](https://www.buymeacoffee.com/FluentTyper)
 
+## Quick Links
 
-# FluentTyper: Autocomplete and Spell Checker
+- Install: [Chrome](https://chrome.google.com/webstore/detail/fluenttyper-autocomplete/mbjlobpodpimgbkmlmjiblnmfgajmebm), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/fluenttyper/), [Edge](https://microsoftedge.microsoft.com/addons/detail/fluenttyper-autocomplete/ljenfpihmhkddgmjoipinkhflinoofcn)
+- Report a bug: [GitHub issue form](https://github.com/bartekplus/FluentTyper/issues/new/choose)
+- Request a feature: [Feature request form](https://github.com/bartekplus/FluentTyper/issues/new?template=feature_request.yml)
+- Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Security policy: [SECURITY.md](SECURITY.md)
+- Sponsor development: [Buy Me a Coffee](https://www.buymeacoffee.com/FluentTyper)
 
-FluentTyper aims to improve the ease and speed of textual input by predicting words. It autocompletes words for you as you type.
+## Why FluentTyper
 
-FluentTyper saves you time when writing, improves your writing with spelling and autocomplete suggestions, and provides text expansions.
+FluentTyper helps you write faster and with fewer mistakes:
 
-FluentTyper also enables you to create intelligent text expansions, allowing you to accomplish more and streamline your work.
+- Predictive autocomplete while typing
+- Spelling suggestions
+- Text expansion snippets for repeated phrases
+- Keyboard-first suggestion selection with arrow keys and `Tab`
 
-Do you ever get tired of typing out long email addresses or frequently used phrases, and wish you could save time when typing on your computer? FluentTyper is here to help!
+Example: type `callMe` and expand it to `Call me back once you're free`.
 
-With FluentTyper, you can type in letter combinations like 'callMe' and have 'Call me back once you're free' appear on your computer screen.
+## Supported Languages
 
-FluentTyper works on most websites, but there are some exceptions, such as Google Docs. If you encounter an incompatible website, please create an issue on [GitHub](https://github.com/bartekplus/FluentTyper), and I'll do my best to resolve it.
-
-FluentTyper values the privacy of your data. It doesn't upload any of your data to the internet, and it works offline. Predictions are generated on your own PC
-
-FluentTyper is a writing assistant with features such as a spell checker, text expander, and predictive auto-complete."
-
-As you start typing, FluentTyper will display a pop-up with a list of suggested words, similar to your phone keyboard.
-You can use the arrow keys (↑, ↓) to navigate the list of suggested words, and then press Tab to confirm your selection.
-To hide the list of suggested words, you can either press the Escape key or continue typing.
-
-Supported languages:
 - English
 - Spanish
 - French
@@ -41,24 +43,71 @@ Supported languages:
 
 ## Installation
 
- - [Chrome](https://chrome.google.com/webstore/detail/fluenttyper-autocomplete/mbjlobpodpimgbkmlmjiblnmfgajmebm)
- - [Firefox](https://addons.mozilla.org/en-US/firefox/addon/fluenttyper/)
- - [Edge](https://microsoftedge.microsoft.com/addons/detail/fluenttyper-autocomplete/ljenfpihmhkddgmjoipinkhflinoofcn)
+- [Chrome](https://chrome.google.com/webstore/detail/fluenttyper-autocomplete/mbjlobpodpimgbkmlmjiblnmfgajmebm)
+- [Firefox](https://addons.mozilla.org/en-US/firefox/addon/fluenttyper/)
+- [Edge](https://microsoftedge.microsoft.com/addons/detail/fluenttyper-autocomplete/ljenfpihmhkddgmjoipinkhflinoofcn)
 
+## Quick Start
 
-## Dependencies
+1. Install FluentTyper from your browser store.
+2. Click any regular text input field on a website.
+3. Start typing to see suggestions.
+4. Use arrow keys to choose a suggestion.
+5. Press `Tab` to accept, or `Esc` to dismiss.
 
-- [Tribute](https://github.com/bartekplus/tribute)
-- [Presage](https://github.com/bartekplus/presage)
-- [Fancier Settings](https://github.com/bartekplus/fancier-settings)
+## Compatibility
 
+FluentTyper works on most websites. Some rich text editors (for example Google Docs) can be partially or fully incompatible.
 
-## Feedback
+If you hit an unsupported site, please open a bug report so compatibility can be improved.
 
-If you have any feedback, please create an issue on [GitHub](https://github.com/bartekplus/FluentTyper).
+## Privacy
 
-## Buy Me a Coffee
+FluentTyper is privacy-first:
 
-<p align="center" width="100%">
-    <a href="https://www.buymeacoffee.com/FluentTyper"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png"></a>
-</p>
+- No upload of your typed content
+- Works offline
+- Predictions are generated locally on your computer
+
+## Bug Reporting
+
+Please report bugs through GitHub Issues using the bug template:
+
+- Issue chooser: [github.com/bartekplus/FluentTyper/issues/new/choose](https://github.com/bartekplus/FluentTyper/issues/new/choose)
+- Direct bug report form: [bug_report.yml](https://github.com/bartekplus/FluentTyper/issues/new?template=bug_report.yml)
+
+To speed up triage, include:
+
+- Steps to reproduce
+- Expected behavior
+- Actual behavior
+- Browser and FluentTyper version
+- Screenshots or recordings when possible
+
+## Feature Requests
+
+Use the feature request form to propose improvements:
+
+- Issue chooser: [github.com/bartekplus/FluentTyper/issues/new/choose](https://github.com/bartekplus/FluentTyper/issues/new/choose)
+- Direct feature form: [feature_request.yml](https://github.com/bartekplus/FluentTyper/issues/new?template=feature_request.yml)
+
+Good feature requests include:
+
+- The problem you want to solve
+- The proposed solution
+- Alternatives you considered
+- Browser context and examples or mockups
+
+## Security
+
+If you discovered a security vulnerability, follow [SECURITY.md](SECURITY.md) and avoid opening a public issue.
+
+## Contributing
+
+Development and contribution guidelines are in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Sponsorship and Support
+
+If FluentTyper saves you time, you can support maintenance and future development:
+
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-Donate-FFDD00?logo=buymeacoffee&logoColor=000000)](https://www.buymeacoffee.com/FluentTyper)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+FluentTyper is maintained on a best-effort basis, with priority given to the latest released version.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities in public GitHub issues.
+
+Use GitHub private vulnerability reporting:
+
+- Create a private advisory: [github.com/bartekplus/FluentTyper/security/advisories/new](https://github.com/bartekplus/FluentTyper/security/advisories/new)
+
+Include:
+
+- A clear description of the issue
+- Steps to reproduce
+- Potential impact
+- Any proof-of-concept details
+- Suggested mitigation (if available)
+
+After submission, maintainers will review and coordinate a fix and disclosure timeline.
+
+## Non-Security Issues
+
+- Product bugs: [Bug report form](https://github.com/bartekplus/FluentTyper/issues/new?template=bug_report.yml)
+- Feature ideas: [Feature request form](https://github.com/bartekplus/FluentTyper/issues/new?template=feature_request.yml)


### PR DESCRIPTION
## Summary
- split docs by audience: user-focused README and developer-focused CONTRIBUTING guide
- add high-visibility sponsorship and explicit bug-reporting guidance in docs
- add GitHub issue forms for bug reports and feature requests
- disable blank issues and configure issue contact links
- add SECURITY.md with private vulnerability reporting process

## Why
- improves onboarding for both users and contributors
- standardizes intake quality for bugs/features
- provides a safe path for security disclosures