### PR TITLE
Migrate CKEditor e2e setup from predefined build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "luxon": "^3.7.2"
       },
       "devDependencies": {
-        "@ckeditor/ckeditor5-build-classic": "^44.3.0",
         "@eslint/js": "^10.0.1",
         "@types/chrome": "^0.1.37",
         "@types/dom-navigation": "^1.0.7",
         "@types/jest": "^30.0.0",
         "@types/luxon": "^3.7.1",
+        "ckeditor5": "^44.3.0",
         "copy-webpack-plugin": "^13.0.1",
         "eslint": "^10.0.2",
         "glob": "^13.0.6",
@@ -654,36 +654,6 @@
         "@ckeditor/ckeditor5-utils": "44.3.0",
         "@ckeditor/ckeditor5-widget": "44.3.0",
         "ckeditor5": "44.3.0"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-build-classic": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-44.3.0.tgz",
-      "integrity": "sha512-tvOwT1dAZlY4v1vZItqR0VFfTzr+OLoEmnOW/Lchl2Y0BUWT99GCfABCvAdakBBYvKdsMLsH0jqZFvnLxJCUmg==",
-      "deprecated": "The predefined builds are no longer maintained. Check the https://ckeditor.com/docs/ckeditor5/latest/updating/nim-migration/predefined-builds.html page for the details.",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "44.3.0",
-        "@ckeditor/ckeditor5-autoformat": "44.3.0",
-        "@ckeditor/ckeditor5-basic-styles": "44.3.0",
-        "@ckeditor/ckeditor5-block-quote": "44.3.0",
-        "@ckeditor/ckeditor5-ckbox": "44.3.0",
-        "@ckeditor/ckeditor5-ckfinder": "44.3.0",
-        "@ckeditor/ckeditor5-cloud-services": "44.3.0",
-        "@ckeditor/ckeditor5-easy-image": "44.3.0",
-        "@ckeditor/ckeditor5-editor-classic": "44.3.0",
-        "@ckeditor/ckeditor5-essentials": "44.3.0",
-        "@ckeditor/ckeditor5-heading": "44.3.0",
-        "@ckeditor/ckeditor5-image": "44.3.0",
-        "@ckeditor/ckeditor5-indent": "44.3.0",
-        "@ckeditor/ckeditor5-link": "44.3.0",
-        "@ckeditor/ckeditor5-list": "44.3.0",
-        "@ckeditor/ckeditor5-media-embed": "44.3.0",
-        "@ckeditor/ckeditor5-paragraph": "44.3.0",
-        "@ckeditor/ckeditor5-paste-from-office": "44.3.0",
-        "@ckeditor/ckeditor5-table": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/bartekplus/FluentTyper#readme",
   "devDependencies": {
-    "@ckeditor/ckeditor5-build-classic": "^44.3.0",
+    "ckeditor5": "^44.3.0",
     "@eslint/js": "^10.0.1",
     "@types/chrome": "^0.1.37",
     "@types/dom-navigation": "^1.0.7",

--- a/tests/e2e/puppeteer-extension.test.ts
+++ b/tests/e2e/puppeteer-extension.test.ts
@@ -540,11 +540,14 @@ describe(`Extension E2E Test [${BROWSER_TYPE}]`, () => {
     domainTestHtml = fs.readFileSync(TEST_PAGE_PATH, "utf8");
 
     domainTestServer = createServer((req, res) => {
-      if (req.url && req.url.includes("ckeditor.js")) {
+      if (
+        req.url &&
+        (req.url.includes("ckeditor5.umd.js") || req.url.includes("ckeditor.js"))
+      ) {
         try {
           const ckeditorPath = path.resolve(
             __dirname,
-            "../../node_modules/@ckeditor/ckeditor5-build-classic/build/ckeditor.js",
+            "../../node_modules/ckeditor5/dist/browser/ckeditor5.umd.js",
           );
           const jsBuf = fs.readFileSync(ckeditorPath);
           res.writeHead(200, {
@@ -555,6 +558,23 @@ describe(`Extension E2E Test [${BROWSER_TYPE}]`, () => {
           return;
         } catch (e) {
           console.error("Failed to load CKEditor from node_modules", e);
+        }
+      }
+      if (req.url && req.url.includes("ckeditor5.css")) {
+        try {
+          const ckeditorCssPath = path.resolve(
+            __dirname,
+            "../../node_modules/ckeditor5/dist/browser/ckeditor5.css",
+          );
+          const cssBuf = fs.readFileSync(ckeditorCssPath);
+          res.writeHead(200, {
+            "Content-Type": "text/css; charset=utf-8",
+            "Content-Length": cssBuf.length,
+          });
+          res.end(cssBuf);
+          return;
+        } catch (e) {
+          console.error("Failed to load CKEditor CSS from node_modules", e);
         }
       }
 

--- a/tests/e2e/test-page.html
+++ b/tests/e2e/test-page.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <title>FluentTyper Test Page</title>
+    <link
+      rel="stylesheet"
+      href="../../node_modules/ckeditor5/dist/browser/ckeditor5.css"
+    />
     <style>
       body {
         font-family:
@@ -133,19 +137,30 @@
       } else {
         const script = document.createElement("script");
         script.src =
-          "../../node_modules/@ckeditor/ckeditor5-build-classic/build/ckeditor.js";
+          "../../node_modules/ckeditor5/dist/browser/ckeditor5.umd.js";
         script.onload = () => {
-          if (!window.ClassicEditor) {
-            window.__testCkEditorError = "ClassicEditor global is unavailable";
+          const CKEDITOR = window.CKEDITOR;
+          if (!CKEDITOR?.ClassicEditor) {
+            window.__testCkEditorError =
+              "CKEDITOR.ClassicEditor is unavailable";
             return;
           }
 
-          window.ClassicEditor.create(
-            document.getElementById("test-ckeditor"),
-            {
-              licenseKey: "GPL",
-            },
-          )
+          const { ClassicEditor, Essentials, Paragraph, Bold, Italic } =
+            CKEDITOR;
+
+          class TestClassicEditor extends ClassicEditor {
+            static builtinPlugins = [Essentials, Paragraph, Bold, Italic];
+            static defaultConfig = {
+              toolbar: {
+                items: ["bold", "italic"],
+              },
+            };
+          }
+
+          TestClassicEditor.create(document.getElementById("test-ckeditor"), {
+            licenseKey: "GPL",
+          })
             .then((editor) => {
               editor.ui.view.editable.element.id = "test-ckeditor-editable";
               window.__testCkEditorReady = true;


### PR DESCRIPTION
## Summary
- replace deprecated `@ckeditor/ckeditor5-build-classic` with `ckeditor5`
- migrate e2e CKEditor script loading to `ckeditor5/dist/browser/ckeditor5.umd.js`
- serve `ckeditor5.css` from the local e2e HTTP server so CKEditor toolbar/icons render correctly
- keep the e2e test-page editor config minimal/stable to avoid harness flakiness

## Validation
- `npm run check`
- `npm run test:e2e` (49/49 passing)

## Notes
- this addresses CKEditor predefined-build deprecation and preserves existing e2e behavior