### PR TITLE
Fix README CI badge and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 Type less, do more. FluentTyper brings smart autocomplete, spell checking, and text expansion to text inputs across the web.
 
-[![Unit and E2E tests](https://github.com/bartekplus/FluentTyper/actions/workflows/test.yml/badge.svg)](https://github.com/bartekplus/FluentTyper/actions/workflows/test.yml)
-[![ESLint and Prettier check](https://github.com/bartekplus/FluentTyper/actions/workflows/lintCheck.yml/badge.svg)](https://github.com/bartekplus/FluentTyper/actions/workflows/lintCheck.yml)
+[![CI (lint, unit, e2e)](https://github.com/bartekplus/FluentTyper/actions/workflows/test.yml/badge.svg)](https://github.com/bartekplus/FluentTyper/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-Support-FFDD00?logo=buymeacoffee&logoColor=000000)](https://www.buymeacoffee.com/FluentTyper)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/dom-navigation": "^1.0.7",
         "@types/jest": "^30.0.0",
         "@types/luxon": "^3.7.1",
-        "ckeditor5": "^44.3.0",
+        "ckeditor5": "^47.5.0",
         "copy-webpack-plugin": "^13.0.1",
         "eslint": "^10.0.2",
         "glob": "^13.0.6",
@@ -560,868 +560,935 @@
       "license": "MIT"
     },
     "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-44.3.0.tgz",
-      "integrity": "sha512-+LYQi4DJmK87Mx3FU7q8Ei3Jv/BrXScR7P1rJVw9bYSySLISw1lPPGEuzNaDm+aI/IMwxAw6Laf7kp+bBfZg1A==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-47.5.0.tgz",
+      "integrity": "sha512-fOAmkBcSIWrGFDoz7kdb9XE/8yU7MnmzJ5JNbDVGNnpX+IL/1xRwvsnipwJzvJn8i3vo25kbyKLrh7FA8CsFtA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-upload": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-upload": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-alignment": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-44.3.0.tgz",
-      "integrity": "sha512-PJLPQPJTaEs/TxmXovb5gZWHFk04VdyFxwpy+LFiVKTewV4T5Mz2jinXwL6+DYmlHh0oDu66O2joSdYeL6F9xw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-47.5.0.tgz",
+      "integrity": "sha512-XI+olNUE92MmD4EMbhPhDmk63wt/b+QGNssH0kG/KjNJ/awoQIe+T9r4/k8WzMK7B2j4mdycgI62+ib5rH6XPw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-44.3.0.tgz",
-      "integrity": "sha512-cKRN73eWaci0px4RL/pu+uFx+/joJyicXjDogqRCqsrHtFnNziAoDxg1aU9F7eReMp+RJc5dqn9R94fZqxdaKQ==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-47.5.0.tgz",
+      "integrity": "sha512-Z9f589prwjroiEJPLRNFqSzaALloOm3oPPUN4jH/YyyRnn1mv+7vI6TEPm7ZLKks3ztBN3yv1hFnrAd9oGqY+g==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-heading": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-heading": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autosave": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-44.3.0.tgz",
-      "integrity": "sha512-vZS8lMUNwtpUplx1WtiywEmgqy2rXSTrwbCqkENZZ6vIOpYZg9sW0XxWAdCMslBiNZRhAF2et3jT+Es01/aEyg==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-47.5.0.tgz",
+      "integrity": "sha512-KKtgL/uJdVLP2srSXG6MbYEZTCjzC2sy3kVcKtkyD6T+q3SA8OWsjH6jCLIPBZkDLNNedNnKnaeUR9+Na4i7Bg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-44.3.0.tgz",
-      "integrity": "sha512-QxwJqzIMYD8Nq7I8utEm2N1wFYve3jR9W1RoxrP005V7F9hXubcG4VFkk1QspVjiPBBtWjYJh7Iq6LjeMnDXgg==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-47.5.0.tgz",
+      "integrity": "sha512-az6yy2hShx9TO9tk9oUEy4akO6V7CKl6d8R4PjGij+PxYeGbiHXSPRMjLrJkoRqj72okl+5S22YmhEf1KIpoPw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-44.3.0.tgz",
-      "integrity": "sha512-J+t36widj2/f1DCZqZjCssOu4hdKCpX/mDWOAJwp4BNIei0NATmtHoblH4Lb98P0mF5UeneoLqR4XZlwMYD7tw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-47.5.0.tgz",
+      "integrity": "sha512-x2T+dn+2CU/r5hmun8AaVwSqNviaod/z483oh0XoexxXDcXE6wLr2FN591INLIdzO4/N2ez3AhcBt0focXYAbg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-enter": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-enter": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-bookmark": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-44.3.0.tgz",
-      "integrity": "sha512-e3p6hUYC4LavTSVTDaz9VfpMaXpi35HNXqqCpIGJGtMKq7mYPaGf1ZZqIPEWuZz3UH/h/E445Mrm4KOgRo9hfg==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-47.5.0.tgz",
+      "integrity": "sha512-5EkwJE5BuVTMHjw3VDKscVbMoG4kxD0wDCN2DTnhRo/drPNZ3q2Jw+3SJigpUrFWYUtzhF0s7+Mm6TL94rSBaA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-link": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-44.3.0.tgz",
-      "integrity": "sha512-R0cHl7aafBU1dvfpFu/dMq+7SMTKa7dAi1wQyu5RqmdN0glCAGXoyffe5h2gujcHGlUqzjGE9oX3207rrPi12A==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-47.5.0.tgz",
+      "integrity": "sha512-OvTjDZSU+XNNzEmny6X3D90lhGF14DsnS00TcYj7uRqiwOUtnWw0ba0Hw4ulJ9Jrfs2CzG+rz2YokMm5iMgQHw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-image": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-upload": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
+        "@ckeditor/ckeditor5-cloud-services": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-image": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-upload": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
         "blurhash": "2.0.5",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckfinder": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-44.3.0.tgz",
-      "integrity": "sha512-h/kQy9nUG2VmxAL28b56xZnVQDrr/N12cu2QE+ODfHIiumMNPPTx2Q+g7s8/eVhKAmNQuZJPXygokjXrirC8TA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-47.5.0.tgz",
+      "integrity": "sha512-QoyPTGypDiPgehwaaykzfH8ZUzr2qhHKj0BC7pqhAuHZaWzdCl49g2ZTI2PlMZRIrYNWr0io5zxQq/elSOgwcA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-image": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-image": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-44.3.0.tgz",
-      "integrity": "sha512-oCQfsHX0Z7RySzszvkpnsFi/p3pqEjpQs4FVpPXXWasK+3F00kWReYNNQFe+0z0eIw7alo/ZzqYTQG/FQHaQUw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-47.5.0.tgz",
+      "integrity": "sha512-LB+KSXasEOL9/3OC2WBPwbLaKd+tDkix+4RVaki9hciQb4XgwQB3q6TWIbKcR1lPjw3Ox8tT/Io11x9AEtOzkg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-cloud-services": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-44.3.0.tgz",
-      "integrity": "sha512-c/jLU3lhoqPmwfwEXcU9fGw0ab6dQUcUjQUjamBH1x92p6NnEJTtXJD97trwgKJryZWZ6bk7vJG5nOC4i0XDZA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-47.5.0.tgz",
+      "integrity": "sha512-lsvOK5w99+GfwQz9UyXaKEbH70+DEy0+wvO+82lgd5vpOiqMYfHz18b1abi5ICCTMo+m3KZyFFj33NoelRWq6w==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-code-block": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-44.3.0.tgz",
-      "integrity": "sha512-LNFRr7OIdvyZTfkmyNW/m48EXTsYdrQyDS/9hp4fpHrv9cC3rHhnP4/rS3vkmPh9FOv5I2JvXS36nn75BjWRRQ==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-47.5.0.tgz",
+      "integrity": "sha512-DdfmlvIu4nRgX41bUTkGlkL0PGJEIKcL3vVRniLXjgqnNrAsR5kWdbYTOu+qSvlCVzr4Z11nAG49QZIJ/aeAGg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-enter": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-clipboard": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-enter": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-44.3.0.tgz",
-      "integrity": "sha512-QYyk00JI2wgE2Lr8/A3roRsms3rSOfwMAF88I6Ff2Qf+c8hT6O11gSX18jdd/bGLhfZ0c4IjWc8v67ohgUdMFg==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-47.5.0.tgz",
+      "integrity": "sha512-4LdO9HIJ/ygN+YC4pty5plmFqlvHmjuQx1zdzzmbL3VSR4MCsaongDX4vVqpUcRVLzxM/1kErP0Da6cpVbkqzw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-watchdog": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-watchdog": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-easy-image": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-44.3.0.tgz",
-      "integrity": "sha512-s1Qpf45/31J4rW4RC0ArKLb5QqD0VKTn9LCB83qhyCLfGluk18MOZ2Fc7gfYoxZClzhCwdMQE6mhWOC9bQUmPw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-47.5.0.tgz",
+      "integrity": "sha512-e71gKQyA0UnSun4XLXawg5SP+IV2N/jhw8mu4FoFcRxhqV51FAwonldzwfdNgfD9lpX6bhYi3gREPGnuwdVPgA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-upload": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-cloud-services": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-upload": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-balloon": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-44.3.0.tgz",
-      "integrity": "sha512-Lw6GIIUW37Pi/ErFqx+ozsqRmbBbvhrJhDJ1zIhILEYcwzADHGP32O2pKGLHDf5Z4QTfwunAyG73jvww/ks3kg==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-47.5.0.tgz",
+      "integrity": "sha512-UrMEb65RrEmV/v/DvPpGIfFVa8KCoVnONALyDRPQ8zsdp745vKuMi+i2jHGGdhKWz6SYDfzJROQ10dq3FMxuuQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-44.3.0.tgz",
-      "integrity": "sha512-Vi1tNQdKUCw6X66X2RPhtJPjXJHw/UqHw1Y0J4Vpmi5rf5UHerEj5Sjn+KrjUwDNbmeHtVO/egibLhwRMjKn8A==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-47.5.0.tgz",
+      "integrity": "sha512-OPu3OiaXm03r+mGhzQMdRyMFnJYMT9VPC8+e91e52GVQh/8sR03rwoow2RbNvsznP/+fAVnH4LrIgRR8K5cgUg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-44.3.0.tgz",
-      "integrity": "sha512-sG4KO0pPhfwQpiegtncDyL9G7nlCsjcWqDieZvRfwy2Uig7EaChny3BoIQhacjO4xKV8ZhXw+dTBJgZRtfePdQ==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-47.5.0.tgz",
+      "integrity": "sha512-bO8+DysIcgdrqo26InvoZ6geyoCBExs/V6c3DPhbG/pUuMXc9F7Zfn/hmKo1iOWL8E+gEJosu7psP/PiYM8RAw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-inline": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-44.3.0.tgz",
-      "integrity": "sha512-asa9uWhdTGA6BDda7leJEj57UT3lkDmFAHPFL7fWsvQpL2mszbdf7P6L/rOedGcj2/7a9F8CZfb5aVmENrM3Zw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-47.5.0.tgz",
+      "integrity": "sha512-L+YSTq7Hlt9nmip9xwPBAW1rNQlS8WGIfgXAgOhcdXsUE7r43PA5gjyckvRB0vKASOF5+c6PTDjiLpapNVnv4g==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-44.3.0.tgz",
-      "integrity": "sha512-2k13l0m9+UGMDOzz2uGkj706iMFsayvn+wp6D4niGUOoDGtKOZSX6gNUwq+WcHJ2+54fsXAAJ2xVZB9juXSuhg==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-47.5.0.tgz",
+      "integrity": "sha512-tpI5VMwT+O3dXktORZ1Z4eCDp9sFEsxxEDDv/mmGz/6s2h+9rjEIfi8KqVnRfEC+uW/H2pu+q6r5y6/S3c+unA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-emoji": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-44.3.0.tgz",
-      "integrity": "sha512-NevoSyV8f9F44oTYFJ8DVaOGmqS1XzCisg/lSW5iwfu2R0+6WXCfU6zlGwp9wVedolznUu5OiYpHK0Emz3dmBw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-47.5.0.tgz",
+      "integrity": "sha512-NVSg4hMpzyq0eVmVugBmY//McJpiyK0/XsXx72qySSh1b4FfKVT1couNB0m1pM5sFm7hXYB33WXyTpB4imyKyA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-mention": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "fuzzysort": "3.1.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-mention": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5",
+        "fuzzysort": "3.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-44.3.0.tgz",
-      "integrity": "sha512-76nq2oHwQocaGQfRKlaDaYYFSps3yVNfbC4204i4/S0moKtB9fSy9IBKwYm5D9iB+0qjqCYGnsn17wWNuKjCYQ==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-47.5.0.tgz",
+      "integrity": "sha512-4T6MzgjV5C7em5VgaHJ+RuN4gipryTErqtjtmb/RJXvfrEg37CYOpdHurM/VwY8hiD7yGUADB2iJGroLtytzCQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-44.3.0.tgz",
-      "integrity": "sha512-M5pv6XC5SIqwa9ZiQQsmmvCAot/uiBN/8ax3KvLz8S78eXDHyHKE6mZMWUd0MJCfZ/0b+CnrFVY/kvZkS+h/7g==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-47.5.0.tgz",
+      "integrity": "sha512-knpo3bZwFURor6gnDN2oS2mAA9qoPvMsEjuS3hce5K6pQAKqyUHqGSIQax7dLBW1spaWExvI+OTi/UNtNyPLWA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-44.3.0.tgz",
-      "integrity": "sha512-DkE6u0pD3gcFLkyZRNA4IZVvjLQUpgoEeTCaB/QaCQRljSSj9300AtkIFpCdRiWo9RAGw7rs9XmVRoCsTPY4tQ==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-47.5.0.tgz",
+      "integrity": "sha512-uEdq/jnWPuN2KL6RufpQW9smnJGnU2f5/a5/QuP+rIfzPmpCmwCjgQto+8/lpCzWvEjUoHUsuIHlIT4TFYUYEQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-enter": "44.3.0",
-        "@ckeditor/ckeditor5-select-all": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-undo": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-clipboard": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-enter": "47.5.0",
+        "@ckeditor/ckeditor5-select-all": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-undo": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-find-and-replace": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-44.3.0.tgz",
-      "integrity": "sha512-d4fLo5IWyxPmfuoIqoaWaekoodgtFurKALc2ZyNvto7H9m+ul+uWwhF4A9buovbETv0N0mertDruGENygiuOCg==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-47.5.0.tgz",
+      "integrity": "sha512-30yr8zzztiVxVmYzKgp8snDWh4sJJc1FbS3UM+u9coNGdlxzpuy9SdseNRPOi+tTXsK1OI6/amWJltYmDsAseA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-font": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-44.3.0.tgz",
-      "integrity": "sha512-F1cdHNbtXkM/1nvqbCO4XeSCHahNiMnwkQqCm36njxuBRXbAei/qTwxqrwPAukE6Yb2q9boX1prUbvEBbPAqhw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-47.5.0.tgz",
+      "integrity": "sha512-qh9GLJ9+9DsdPXgZg8dH8D5mv/ZZ0mK+Ulwct0rSxIBLruFK5EhjXjngIG8HUv30BGCIpXPawGDTPv2txQ4vlw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen": {
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-47.5.0.tgz",
+      "integrity": "sha512-cdgpNSOKrqKZMslG9hnQQoWRUy+tAVi7r0oGIbDfMezvLnaJDoG7GmYSWbGe1/+l90/TMtxKwYM7cQ6dmqutFA==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-editor-classic": "47.5.0",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-44.3.0.tgz",
-      "integrity": "sha512-7uCSHN2UMTzn/nZpoACOiUyx2dX4ZlC8bfLbpdgMhDPM9vEaa0Tr/lgSFD5C1ugLFFSEJL3pAPGWStvZ4wD6YA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-47.5.0.tgz",
+      "integrity": "sha512-TEHY+unz+1fnx3554TgoYNGw27Vct7aDm0qw0U5/+PkZIyAxLcElkzRqXu3HhAPy6qs6pqxpPfKWWtREJhKluQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-paragraph": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-paragraph": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-highlight": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-44.3.0.tgz",
-      "integrity": "sha512-BwdMrcAbS0J/3q3dmtY0F6sVARVR9oSrWj4/850EfXp0hw9gkpQyEjrds17sIrIchCG+/8/0LM4Z9sADYzmo9w==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-47.5.0.tgz",
+      "integrity": "sha512-ajLkP2jA51B+K83g/Ujyuvpe+Wst9iniPBASmMn03pkC3ZNkdDRtCmz1Kkhe0UpYIvhCIKeWHIaH+7BS0DlbAQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-horizontal-line": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-44.3.0.tgz",
-      "integrity": "sha512-k8YuWptng4IKUbXVE+ZjVyNm8JpGU50aFWckYunimlpajNOKC52L8pneIEqIHr/BjA+2P/vtAIf8HDZs+AoNjw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-47.5.0.tgz",
+      "integrity": "sha512-/lPpkiish+KLFCV+oSJ11XldS4MJdOogfKAtWkpdlzLS64/Duw0fxOUTk8lzo3tHAgZgP7Ji9FJM1HtiNehTNw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-embed": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-44.3.0.tgz",
-      "integrity": "sha512-rJV3ikojykVPw9CrtzInh8DsgGuk/2UOi8KUr3b6DEtuYOqJkG5cfpqRy5QVoSRbtpLhVOWNpEKhYGgiv+HUgw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-47.5.0.tgz",
+      "integrity": "sha512-7gDouRaElSoICODnCwmziNxKJnvApur/QPLt374q7gz2l3sCrSM7LuDuCDAXWTQGQGkA1291OrOKQtuXGwY/xQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-support": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-44.3.0.tgz",
-      "integrity": "sha512-KFBHMzBNU9/YBj3Eil03qYBLNk7wAuholdZ3YijohgCt2YRw1cRu9krjGaOyhF9E5MEu0cqTJvTjPGBhGE8mVQ==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-47.5.0.tgz",
+      "integrity": "sha512-e/OuWdlh6EbE1ZrQDu0/QnMd+V1XdwTmUJkOQrwwZ0x8CSKvKOt+Nb40ac0ShjTE190dMD1tGfOjM0yDpp0neQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-enter": "44.3.0",
-        "@ckeditor/ckeditor5-heading": "44.3.0",
-        "@ckeditor/ckeditor5-image": "44.3.0",
-        "@ckeditor/ckeditor5-list": "44.3.0",
-        "@ckeditor/ckeditor5-table": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-enter": "47.5.0",
+        "@ckeditor/ckeditor5-heading": "47.5.0",
+        "@ckeditor/ckeditor5-image": "47.5.0",
+        "@ckeditor/ckeditor5-list": "47.5.0",
+        "@ckeditor/ckeditor5-remove-format": "47.5.0",
+        "@ckeditor/ckeditor5-table": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-icons": {
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-47.5.0.tgz",
+      "integrity": "sha512-1LKzMsMrKHOEtLc9rw2C6iV5Wx6YCjd8I4WxFKQnxtW+F7+e4H4+rWU7ILpUxYjubEx0FSUJsyyNB9B98GMUgg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md"
+    },
     "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-44.3.0.tgz",
-      "integrity": "sha512-3mRgGSOXQ4e/TJZcB7N8SPSnN+pdUzA72kwiN6FrjjdV0CNqehNoSUCFrwra4ctHaFjLBBqFVV+hEvwFlgmlxA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-47.5.0.tgz",
+      "integrity": "sha512-Zm9Qvj5UUC+bKHtQNmPJisTS9Sy1z6UQ6pbH2OxKPcw7ckhozQIeRtZQqoSSKQWq9B9iJ+CPvE3b+7FYkOXkew==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-undo": "44.3.0",
-        "@ckeditor/ckeditor5-upload": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-clipboard": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-undo": "47.5.0",
+        "@ckeditor/ckeditor5-upload": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-44.3.0.tgz",
-      "integrity": "sha512-Gju3Lt2/OQB2mzhk/TTtonHTEcmFua4Ag4keB75EbPxthpLZZnMQm3Gl7MvrecjUv4+3nRlEBv/Bon00OIXcqA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-47.5.0.tgz",
+      "integrity": "sha512-ZioulqHdwXBqirZGwESdkXWiYa1AE+EVbhegMO+a8tNa+SCDIt4do5PsrWxyz+PtW5jGBTKY831TY4NIGTihvQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-heading": "44.3.0",
-        "@ckeditor/ckeditor5-list": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-heading": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-list": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-language": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-44.3.0.tgz",
-      "integrity": "sha512-lnhnnsSwMnnyFpUktrvAxuj6tlwn2zjSm7+ZDxMiQpsZuRsmABnSapeKqjlfs8B1rQwrcZIhp1FsHVvnaVOzug==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-47.5.0.tgz",
+      "integrity": "sha512-BSSUxiqXNGEz9knYTgMJF6wpKjCY9NEsFBmfVzsXiIuNpYSXrS281Efl49E1ivjlnsgyEJLvmed6DOa+mkUHpQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-44.3.0.tgz",
-      "integrity": "sha512-OmOWje1i7tuEBNHoIi/n6M69xE1K97P2xmbSJ9HB5nFFvelfCCMnuLa+7QmT1+/Sxg0VYM175dtTclinEeWJhQ==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-47.5.0.tgz",
+      "integrity": "sha512-sxsB0dSEsJL1g+GTJ4dTQ33eulS4/mZ2wwU8TgN5EtpPjGR1DcsFM/Hbhpr+nC6pyGfYzjV5GnhgOT/aYGE2lg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-bookmark": "44.3.0",
-        "@ckeditor/ckeditor5-clipboard": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-image": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-clipboard": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-image": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-44.3.0.tgz",
-      "integrity": "sha512-66f3n8ASdhA7wxPoGt/sI+Eg/IhDFutSkCEcqL2tsJFVRB0MuhhQIklxdGRVfPrjbpMSUPSRJPMddAFhRCzfUQ==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-47.5.0.tgz",
+      "integrity": "sha512-9Yq2Jsgebbdxe6As3jviwFXL4CH38Mb+YUjlO2oEZZEw6fDvwjc83ziBXA/t+6cyBTdLjibbFhGLyPeiy+Y0Lw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-enter": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-clipboard": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-enter": "47.5.0",
+        "@ckeditor/ckeditor5-font": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-44.3.0.tgz",
-      "integrity": "sha512-q+vblaqjjwQQkcrFfsOCD7ejWl1ltqV982jfFK9LTx7DiJIuR2UwByNrRC00Xeol2rDeC8lYoIH77AZHavFIbw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-47.5.0.tgz",
+      "integrity": "sha512-sxttfFji9jTHDKdDklN13w480tI+tLwATIOHO2xTDbsA18tp8opeBFNUUfEeQ8XoZkAxckwv5tFu9Au2XuAdJg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@types/marked": "4.3.2",
-        "@types/turndown": "5.0.5",
-        "ckeditor5": "44.3.0",
-        "marked": "4.0.12",
-        "turndown": "7.2.0",
-        "turndown-plugin-gfm": "1.0.2"
+        "@ckeditor/ckeditor5-clipboard": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@types/hast": "3.0.4",
+        "ckeditor5": "47.5.0",
+        "hast-util-from-dom": "5.0.1",
+        "hast-util-to-html": "9.0.5",
+        "hast-util-to-mdast": "10.1.2",
+        "hastscript": "9.0.1",
+        "rehype-dom-parse": "5.0.2",
+        "rehype-dom-stringify": "4.0.2",
+        "rehype-remark": "10.0.1",
+        "remark-breaks": "4.0.0",
+        "remark-gfm": "4.0.1",
+        "remark-parse": "11.0.0",
+        "remark-rehype": "11.1.2",
+        "remark-stringify": "11.0.0",
+        "unified": "11.0.5",
+        "unist-util-visit": "5.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-44.3.0.tgz",
-      "integrity": "sha512-wlAITZKeNEZfB164hwODXfhg63pYaWynCuIvVCtaeVUmoBqnSkK8gxuZ2ehxUdi4SPlVJwt84afDsD4RU8UYDQ==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-47.5.0.tgz",
+      "integrity": "sha512-aA+MALRNzyeXcfXoEKDJiun0VU5p8llVrXibrXKBK4Kpx53TdBd75+OUe4z8wOcKYN50ntRf7YSGCLB0yqJuLw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-undo": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-clipboard": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-undo": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-mention": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-44.3.0.tgz",
-      "integrity": "sha512-pmf7prEvIJgP4rbyeTtY6Ynl2i5jo52G+DlFwJbWUzZDyOZIR41mh4hBimK50QHR0szaXMBGbM+alFu924vZCA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-47.5.0.tgz",
+      "integrity": "sha512-AhfdHcG6TNRLP/gEJIPdZM792vbjzQUR6lwXy7vFRIfVwDZ+qanEIKsTJue0x1oJYkdxC0hSRx2ZN+4QHwEOFw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-minimap": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-44.3.0.tgz",
-      "integrity": "sha512-iRO1t1lyeyiFZg4il5JGRVwyoqRYqsRcj9uSh90xNJJAxH5yiPlWAGIvCMzWDwlINFJe/hfaNd0RDzlbNHytgA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-47.5.0.tgz",
+      "integrity": "sha512-GarVZ6e29UY6KWlKZcCQRgEggU1oqep3J6wiXJ0hxrcvYOsDS06Zo326xdcs9zQEC3M/siBO/4WW77gBZdjB0Q==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-page-break": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-44.3.0.tgz",
-      "integrity": "sha512-PzvOsEDNBPWCtN9S6nhJPWYwF/5BoE0klXkNzTgoA28EwsoSA4evU8gztcoxxGkVOskdI2OzZfz1QUaPFczLDQ==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-47.5.0.tgz",
+      "integrity": "sha512-e7//l3ls4vVsRXcsX9Lg6r9EBjT5Aq6UfHB5KWpi3bH+S2tqE8CoeQZPKFF7fa6W2V1BVUolkUeN72iiOkCi6w==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-44.3.0.tgz",
-      "integrity": "sha512-kxZBn/xmz+woXB0fIKWA/ZrFZXqyubX5BhcOYpM2j3CtjsJUJsL6ekwBq/y9HNSkkKfNKHaTzK7IDiPBKblcrw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-47.5.0.tgz",
+      "integrity": "sha512-dEOJ876f8kvpkNBCOSj9g+2x6Ig9e41k0Gdp3WrkNcX+3QCthNeWa5XJfPDsQqTINldv+L9GBwxgFEMRi0Fq/g==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-44.3.0.tgz",
-      "integrity": "sha512-IHl3YVE6ONGXTxHf+uHvvBMFR90nxTz7nB9eA8DzuWskF+fOo+wtVdfZaafLUs0kJJXBTRebsv2Sa5onLLL6tA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-47.5.0.tgz",
+      "integrity": "sha512-xF9TXExWPPVgIEA1gxf+oFNMVSOsbpGgRSNKS23gN5scxLupNGN/G1hj0UGTgHaYczBiOqW44bu82Lgduz7/GQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-clipboard": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-remove-format": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-44.3.0.tgz",
-      "integrity": "sha512-ZlbJNaX+IGui9C3NDC/W/4M308RzD3+jnk5iDGXENjBstNB99AnwpfDXel+Tc0t5rTd7D1fSr9eaxScnPLdgwA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-47.5.0.tgz",
+      "integrity": "sha512-QTR9ye1iWfnGu7h5a4RONEf2e4y21dC847opNUozO06g51/e7G6iXybEcRtBqs51gpVddKelUbxUV2Zp7tm8iw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-restricted-editing": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-44.3.0.tgz",
-      "integrity": "sha512-0V/can4jw70DMBPwex1MRiUHRsvFdbjZp/RaHagazen6gOZZOAo3R7vJjp+qBQrHmXP6T6aTGn89Y9NxYI9OIw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-47.5.0.tgz",
+      "integrity": "sha512-hL6pr3L1xaERwGBNG37AcLwj5XVXqAzYUWKF/pDbT8FnHymA7jn1dbsUHHbmPaqXtk8zu7W9k+aGKXwrkPUFVg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-44.3.0.tgz",
-      "integrity": "sha512-GDNl6Iex1cyHAQgjR6cqIklH8QPO1x1Z87gwi93lX3mgm47DW6Q12jvwfRc36+d1zGf5W7+eH0xaP7jQPWYUPg==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-47.5.0.tgz",
+      "integrity": "sha512-g+bLHv5aqgtuGhqLo9FNYS4aSGZztb15myydHXvUBJ7OgY3YlVDILi0xd9WrySPpO+Axi0ATdl9evO42rPYVJg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-show-blocks": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-44.3.0.tgz",
-      "integrity": "sha512-4Qp992YWOby7+MiyX0PwD8bg/+PgsRFNXd9DLyhCvmmiFmkwUzbYmA8t3lp+V3uefg5SrcylzWn4QHlUNVg1iw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-47.5.0.tgz",
+      "integrity": "sha512-G902a+fvVv9IMcLm634yaehf7VYwWrSZqRQtD+rpV2wDaHcps5aXCHSPNrk5JdbInheF1d+V3uiySzbkc823IA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-source-editing": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-44.3.0.tgz",
-      "integrity": "sha512-OCv2oO6ok0UrZJHOoJRnywFpv3+UntOs7TuvEw35zDYJCgcmICfzqqTZ++ZcZaq1oOERbwk2L4E4uy2H8KXWQA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-47.5.0.tgz",
+      "integrity": "sha512-YmTaRSVkbx441xa9foOz/z+cYqJ385yKC6cW+MACsDVdHj2ruvj1QUDrRpvPc8T0irTSAuhxQhhmCSIEnt61WQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-theme-lark": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-theme-lark": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-special-characters": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-44.3.0.tgz",
-      "integrity": "sha512-K3cOw/aMUmkXofUVFpUXTHLNYlwvcT3KUyfvTO3oT8ae3ecQlG4btTjgnzgVD2zIXFSEpguSBYywVUhMAZWNMA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-47.5.0.tgz",
+      "integrity": "sha512-Wou/dBJnv3Qiuz7io8YTL5LJGS3JqiGwpw6nLKPxADinZfI8Rr+ZOvw5BL8ifYkPudOwLFKFwMY3/4I7tZQAhA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-style": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-44.3.0.tgz",
-      "integrity": "sha512-IUd5yRea8uh/VyAJ6p1NdXL9wWywQYfIOubzNgiP1b58q0psfWYxwsREekE6Epd+sMHC1H4wc+dZsIxfi+stKw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-47.5.0.tgz",
+      "integrity": "sha512-JmXOZQvRoOeNotZyXdColDncBw9GIl6nFbL8lVHZL/BF6wFxRHlJSjy7W/VdYAsHv3GaOKlKWMRg72k+17mgUg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-html-support": "44.3.0",
-        "@ckeditor/ckeditor5-list": "44.3.0",
-        "@ckeditor/ckeditor5-table": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-html-support": "47.5.0",
+        "@ckeditor/ckeditor5-list": "47.5.0",
+        "@ckeditor/ckeditor5-table": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-44.3.0.tgz",
-      "integrity": "sha512-kFPvQWe/7Iq9tPzq788HLax7Ss8SJaS5+bkhbUmH+k4RM4NABl1ABRa+EzyMIrdqz9KLYr0B57jUoCU8Y2HLsg==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-47.5.0.tgz",
+      "integrity": "sha512-aB4Sn9+DLuDHd5pn5d/QdSGQYzGBLJg2+zlzSddcxSeUS0gj7qtOhtce2ChY899D1pszbdQHXbM/Lnwgy1ZrCQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-clipboard": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-theme-lark": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-44.3.0.tgz",
-      "integrity": "sha512-Druy7S1e3bjwMVLkld7ZPGIU6tdI9E6bn/AS+OrQF3mDck14mFP+K4qnMbYNCeYngMqv8Se0eSHtAmQhU7It0A==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-47.5.0.tgz",
+      "integrity": "sha512-vmQJyT6UnsmTF9rIWhYWWRGGpDhoxo9vd7aJ+m3b+gJqCLMziGadP6Dz3dezDQpbaW41Fk5CF61QPnMqaHuk7g==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "44.3.0"
+        "@ckeditor/ckeditor5-ui": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-44.3.0.tgz",
-      "integrity": "sha512-ojAuhhd/PfO5Oko94ObgEmuvQzqApARb2H0R5YEySSRj9oek4Nm1NGMhHMvIC0sMP2hSVxhfSbHcHY3vDjGwiA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-47.5.0.tgz",
+      "integrity": "sha512-/MoO59Cl/XJ4f79ecc5BHBb0sEnZttMosXpm1wjhwRKE7PyEICt2t+Uqi0zp9txl21O2z+Gmjz716X5InMa/4w==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-44.3.0.tgz",
-      "integrity": "sha512-Sotme1g/xwhmDYes+bXEU/9hbGXcaKC952Yck6UiYgZyhei28lErlNwtSOAKfpQ2gHbPjWRt7rigSH22EN+iqw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-47.5.0.tgz",
+      "integrity": "sha512-wn55rqImjQ44CPavijdc9+MGHZZJ9lS9++NEAmt95b45ywd9nAyJ4QcuXDZ6f+xjwfeTuLX7jhBSuz7w8FWcwA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
         "@types/color-convert": "2.0.4",
-        "color-convert": "2.0.1",
-        "color-parse": "1.4.2",
-        "lodash-es": "4.17.21",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
         "vanilla-colorful": "0.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-44.3.0.tgz",
-      "integrity": "sha512-cogFPl7QoDrmoUPKTZI0/LiUYoFboqm0lqBK168nh5VRgy53RuGgbXJ4+hCOHNuzdUnVUlWvl/2u0vR4/R07+A==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-47.5.0.tgz",
+      "integrity": "sha512-StiwvLrAlRqog1BSR8YZ5S6pdUdFB5BCPWPPJEAcMiBfRmG4pSzs+k3LIMgnyVoGwGBUcjdLVayqaESxe89Oeg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-44.3.0.tgz",
-      "integrity": "sha512-oJgsw374nHeVKx1qvnlQzEyDhfFvC/su84f00nOdDGWfsHabU3hE0hZE+yoBtreRViORwwe6Ftg5qbhl5OVyuA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-47.5.0.tgz",
+      "integrity": "sha512-F1DPVYUGsb9P1/35vqPk7E+Y7wlubyb51DDR9irjUCAFyqQzolVQJ2bcsvrUXx+P8LT63sLCzH2do0pwMacGyQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-44.3.0.tgz",
-      "integrity": "sha512-Z/ttfLhu9QnuMc9BBdQfH9Do6JD01ijUkUmUB41BPByYfOjZbGYGfZmhywH9OjXmHnSDQSUqwRnxqqM3nceR1g==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-47.5.0.tgz",
+      "integrity": "sha512-gkjlbVLjqkmZXo1lacY0kHRi9FTZjfJfL/OkF6WGauh0VLoDAIJHIv73PjqH6Sh7nF0Dx2p78NJ42W0t/KWxug==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@types/lodash-es": "4.17.12",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-watchdog": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-44.3.0.tgz",
-      "integrity": "sha512-7Y4FOWB021CLEUDsIf61tZzd9ZrZ8JkD8lQeRZOmv+bBLTxgjyz2/7MCjIDR7NN0xdASXTFwRS6XO32HbdrN0Q==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-47.5.0.tgz",
+      "integrity": "sha512-nmSnCvCvf9ChNS2C5YIdszSMeoGQRvd+CD4cDtLmkmaBqSuV/kePr5nGvqT8lMt5MrMtdqG/KmgE/xxmE4QIHg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-44.3.0.tgz",
-      "integrity": "sha512-nFEKBE33RnZ2bOeD9L9jfyKYaFw/xKY543ZNQWxWHcmI70AX3U2KJ8wUnuMjMknHafyMuH6bSlWjKtn5vz3w+g==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-47.5.0.tgz",
+      "integrity": "sha512-o8wFSP5Dx2kR6t2XDzpdw1IZoqOrCXdJ51iZvClsUn6zQ+EosZonlmej8oA96ZsRK/nw9GOSt2cM0Snzv3zDtQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-enter": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-enter": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-word-count": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-44.3.0.tgz",
-      "integrity": "sha512-9iNiF1wq1f9npT/KhBAgDfM6kFbJ0GyUdlXt3V6zyLY2K3SILQ6q5B23jhtABZny8zxA+f528ClxDSTFh9bXDA==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-47.5.0.tgz",
+      "integrity": "sha512-zsATU4eI7iFWC+3axpj9JG7Gm6IRzDzjW8fQqYho0xMc3hN71XxgIbPZR7jLpwNo29WirCsNxAfqi4Q2Ws8c6w==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "ckeditor5": "44.3.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "ckeditor5": "47.5.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -2281,9 +2348,9 @@
       "license": "ISC"
     },
     "node_modules/@jest/reporters/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.8.tgz",
+      "integrity": "sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2496,13 +2563,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mixmark-io/domino": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
-      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2700,6 +2760,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/dom-navigation": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/dom-navigation/-/dom-navigation-1.0.7.tgz",
@@ -2767,6 +2837,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2824,23 +2904,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/luxon": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
@@ -2848,17 +2911,27 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/marked": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
-      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "version": "25.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.1.tgz",
+      "integrity": "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2879,10 +2952,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/turndown": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.5.tgz",
-      "integrity": "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==",
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3802,6 +3875,26 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -3972,6 +4065,17 @@
         "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3998,9 +4102,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.4.tgz",
-      "integrity": "sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
+      "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -4024,9 +4128,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.0.tgz",
+      "integrity": "sha512-64Rcwj8qlnTZU8Ps6JJEdSmxBEUGgI7g8l+lMtsJLl4IsfTcHMTfJ188u2iGV6P6YPRZrtv72B2kjn+hp+Yv3g==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -4309,6 +4413,17 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4334,6 +4449,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -4384,71 +4532,73 @@
       "license": "MIT"
     },
     "node_modules/ckeditor5": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-44.3.0.tgz",
-      "integrity": "sha512-g2arr/fejYAiOkdMeYvz1ficRPJ42OvO+pYROhre08YjIbAtJBr8wO9DPk9nCV3msnyYE+B02bs+TppazhYNtw==",
+      "version": "47.5.0",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-47.5.0.tgz",
+      "integrity": "sha512-Ow4eLxOxXoaIeuugBh4fCidLuu3zICInWO6ugB0+nZRGn9dfz9ENfdk6UlShyV2B0C5Ocu2n6Fm6I5hlByC/qA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "44.3.0",
-        "@ckeditor/ckeditor5-alignment": "44.3.0",
-        "@ckeditor/ckeditor5-autoformat": "44.3.0",
-        "@ckeditor/ckeditor5-autosave": "44.3.0",
-        "@ckeditor/ckeditor5-basic-styles": "44.3.0",
-        "@ckeditor/ckeditor5-block-quote": "44.3.0",
-        "@ckeditor/ckeditor5-bookmark": "44.3.0",
-        "@ckeditor/ckeditor5-ckbox": "44.3.0",
-        "@ckeditor/ckeditor5-ckfinder": "44.3.0",
-        "@ckeditor/ckeditor5-clipboard": "44.3.0",
-        "@ckeditor/ckeditor5-cloud-services": "44.3.0",
-        "@ckeditor/ckeditor5-code-block": "44.3.0",
-        "@ckeditor/ckeditor5-core": "44.3.0",
-        "@ckeditor/ckeditor5-easy-image": "44.3.0",
-        "@ckeditor/ckeditor5-editor-balloon": "44.3.0",
-        "@ckeditor/ckeditor5-editor-classic": "44.3.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "44.3.0",
-        "@ckeditor/ckeditor5-editor-inline": "44.3.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "44.3.0",
-        "@ckeditor/ckeditor5-emoji": "44.3.0",
-        "@ckeditor/ckeditor5-engine": "44.3.0",
-        "@ckeditor/ckeditor5-enter": "44.3.0",
-        "@ckeditor/ckeditor5-essentials": "44.3.0",
-        "@ckeditor/ckeditor5-find-and-replace": "44.3.0",
-        "@ckeditor/ckeditor5-font": "44.3.0",
-        "@ckeditor/ckeditor5-heading": "44.3.0",
-        "@ckeditor/ckeditor5-highlight": "44.3.0",
-        "@ckeditor/ckeditor5-horizontal-line": "44.3.0",
-        "@ckeditor/ckeditor5-html-embed": "44.3.0",
-        "@ckeditor/ckeditor5-html-support": "44.3.0",
-        "@ckeditor/ckeditor5-image": "44.3.0",
-        "@ckeditor/ckeditor5-indent": "44.3.0",
-        "@ckeditor/ckeditor5-language": "44.3.0",
-        "@ckeditor/ckeditor5-link": "44.3.0",
-        "@ckeditor/ckeditor5-list": "44.3.0",
-        "@ckeditor/ckeditor5-markdown-gfm": "44.3.0",
-        "@ckeditor/ckeditor5-media-embed": "44.3.0",
-        "@ckeditor/ckeditor5-mention": "44.3.0",
-        "@ckeditor/ckeditor5-minimap": "44.3.0",
-        "@ckeditor/ckeditor5-page-break": "44.3.0",
-        "@ckeditor/ckeditor5-paragraph": "44.3.0",
-        "@ckeditor/ckeditor5-paste-from-office": "44.3.0",
-        "@ckeditor/ckeditor5-remove-format": "44.3.0",
-        "@ckeditor/ckeditor5-restricted-editing": "44.3.0",
-        "@ckeditor/ckeditor5-select-all": "44.3.0",
-        "@ckeditor/ckeditor5-show-blocks": "44.3.0",
-        "@ckeditor/ckeditor5-source-editing": "44.3.0",
-        "@ckeditor/ckeditor5-special-characters": "44.3.0",
-        "@ckeditor/ckeditor5-style": "44.3.0",
-        "@ckeditor/ckeditor5-table": "44.3.0",
-        "@ckeditor/ckeditor5-theme-lark": "44.3.0",
-        "@ckeditor/ckeditor5-typing": "44.3.0",
-        "@ckeditor/ckeditor5-ui": "44.3.0",
-        "@ckeditor/ckeditor5-undo": "44.3.0",
-        "@ckeditor/ckeditor5-upload": "44.3.0",
-        "@ckeditor/ckeditor5-utils": "44.3.0",
-        "@ckeditor/ckeditor5-watchdog": "44.3.0",
-        "@ckeditor/ckeditor5-widget": "44.3.0",
-        "@ckeditor/ckeditor5-word-count": "44.3.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "47.5.0",
+        "@ckeditor/ckeditor5-alignment": "47.5.0",
+        "@ckeditor/ckeditor5-autoformat": "47.5.0",
+        "@ckeditor/ckeditor5-autosave": "47.5.0",
+        "@ckeditor/ckeditor5-basic-styles": "47.5.0",
+        "@ckeditor/ckeditor5-block-quote": "47.5.0",
+        "@ckeditor/ckeditor5-bookmark": "47.5.0",
+        "@ckeditor/ckeditor5-ckbox": "47.5.0",
+        "@ckeditor/ckeditor5-ckfinder": "47.5.0",
+        "@ckeditor/ckeditor5-clipboard": "47.5.0",
+        "@ckeditor/ckeditor5-cloud-services": "47.5.0",
+        "@ckeditor/ckeditor5-code-block": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.5.0",
+        "@ckeditor/ckeditor5-easy-image": "47.5.0",
+        "@ckeditor/ckeditor5-editor-balloon": "47.5.0",
+        "@ckeditor/ckeditor5-editor-classic": "47.5.0",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.5.0",
+        "@ckeditor/ckeditor5-editor-inline": "47.5.0",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.5.0",
+        "@ckeditor/ckeditor5-emoji": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-enter": "47.5.0",
+        "@ckeditor/ckeditor5-essentials": "47.5.0",
+        "@ckeditor/ckeditor5-find-and-replace": "47.5.0",
+        "@ckeditor/ckeditor5-font": "47.5.0",
+        "@ckeditor/ckeditor5-fullscreen": "47.5.0",
+        "@ckeditor/ckeditor5-heading": "47.5.0",
+        "@ckeditor/ckeditor5-highlight": "47.5.0",
+        "@ckeditor/ckeditor5-horizontal-line": "47.5.0",
+        "@ckeditor/ckeditor5-html-embed": "47.5.0",
+        "@ckeditor/ckeditor5-html-support": "47.5.0",
+        "@ckeditor/ckeditor5-icons": "47.5.0",
+        "@ckeditor/ckeditor5-image": "47.5.0",
+        "@ckeditor/ckeditor5-indent": "47.5.0",
+        "@ckeditor/ckeditor5-language": "47.5.0",
+        "@ckeditor/ckeditor5-link": "47.5.0",
+        "@ckeditor/ckeditor5-list": "47.5.0",
+        "@ckeditor/ckeditor5-markdown-gfm": "47.5.0",
+        "@ckeditor/ckeditor5-media-embed": "47.5.0",
+        "@ckeditor/ckeditor5-mention": "47.5.0",
+        "@ckeditor/ckeditor5-minimap": "47.5.0",
+        "@ckeditor/ckeditor5-page-break": "47.5.0",
+        "@ckeditor/ckeditor5-paragraph": "47.5.0",
+        "@ckeditor/ckeditor5-paste-from-office": "47.5.0",
+        "@ckeditor/ckeditor5-remove-format": "47.5.0",
+        "@ckeditor/ckeditor5-restricted-editing": "47.5.0",
+        "@ckeditor/ckeditor5-select-all": "47.5.0",
+        "@ckeditor/ckeditor5-show-blocks": "47.5.0",
+        "@ckeditor/ckeditor5-source-editing": "47.5.0",
+        "@ckeditor/ckeditor5-special-characters": "47.5.0",
+        "@ckeditor/ckeditor5-style": "47.5.0",
+        "@ckeditor/ckeditor5-table": "47.5.0",
+        "@ckeditor/ckeditor5-theme-lark": "47.5.0",
+        "@ckeditor/ckeditor5-typing": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-undo": "47.5.0",
+        "@ckeditor/ckeditor5-upload": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-watchdog": "47.5.0",
+        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "@ckeditor/ckeditor5-word-count": "47.5.0"
       }
     },
     "node_modules/cliui": {
@@ -4500,33 +4650,36 @@
       "license": "MIT"
     },
     "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-name": "~1.1.4"
+        "color-name": "^2.0.0"
       },
       "engines": {
-        "node": ">=7.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/color-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
-      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-name": "^1.0.0"
+        "color-name": "^2.0.0"
       }
     },
     "node_modules/colorette": {
@@ -4547,6 +4700,17 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -4748,6 +4912,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
@@ -4805,6 +4983,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -4813,6 +5001,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/devtools-protocol": {
@@ -4996,6 +5198,17 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.5",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.5.tgz",
+      "integrity": "sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5302,6 +5515,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -5933,6 +6153,245 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-dom": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-dom/-/hast-util-to-dom-4.0.1.tgz",
+      "integrity": "sha512-z1VE7sZ8uFzS2baF3LEflX1IPw2gSzrdo3QFEsyoi23MkCVY3FoE9x6nLgOgjwJu8VNWgo+07iaxtONhDzKrUQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "property-information": "^7.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -5965,6 +6424,17 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -6224,6 +6694,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-object": {
@@ -6575,9 +7058,9 @@
       "license": "ISC"
     },
     "node_modules/jest-config/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.8.tgz",
+      "integrity": "sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7199,9 +7682,9 @@
       "license": "ISC"
     },
     "node_modules/jest-runtime/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.8.tgz",
+      "integrity": "sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7624,13 +8107,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7650,6 +8126,17 @@
       "funding": {
         "type": "tidelift",
         "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -7717,17 +8204,15 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
       "dev": true,
       "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7740,11 +8225,852 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -7795,9 +9121,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -7909,9 +9235,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-19.4.1.tgz",
-      "integrity": "sha512-g3s+khrneBo0iGx7xqu/cQUk0Qc1XAHEYDptPCyCFF447RdhiBd6yPRxB7GkesbUBHXeNfmqV3ArlwxcI8h56w==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-19.5.0.tgz",
+      "integrity": "sha512-isVbxtTABSULTmWUvoMOmaw6PdtF6t5vz78sCDlfAtzgQge8fd1kExCxe4e61BQADp20Q0SivWb8s9Y0azDUVg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8393,6 +9719,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
@@ -8584,6 +9921,149 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/rehype-dom-parse": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-parse/-/rehype-dom-parse-5.0.2.tgz",
+      "integrity": "sha512-8CqP11KaqvtWsMqVEC2yM3cZWZsDNqqpr8nPvogjraLuh45stabgcpXadCAxu1n6JaUNJ/Xr3GIqXP7okbNqLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "node_modules/rehype-dom-stringify": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-stringify/-/rehype-dom-stringify-4.0.2.tgz",
+      "integrity": "sha512-2HVFYbtmm5W3C2j8QsV9lcHdIMc2Yn/ytlPKcSC85/tRx2haZbU8V67Wxyh8STT38ZClvKlZ993Me/Hw8g88Aw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-dom": "^4.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -8941,6 +10421,17 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spawnd": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-11.0.0.tgz",
@@ -9053,6 +10544,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -9375,9 +10881,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9519,6 +11025,39 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -9664,23 +11203,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/turndown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
-      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mixmark-io/domino": "^2.2.0"
-      }
-    },
-    "node_modules/turndown-plugin-gfm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
-      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -9718,9 +11240,9 @@
       }
     },
     "node_modules/typed-query-selector": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9782,6 +11304,114 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -9881,6 +11511,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -9936,6 +11596,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webdriver-bidi-protocol": {
@@ -10362,6 +12033,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/bartekplus/FluentTyper#readme",
   "devDependencies": {
-    "ckeditor5": "^44.3.0",
+    "ckeditor5": "^47.5.0",
     "@eslint/js": "^10.0.1",
     "@types/chrome": "^0.1.37",
     "@types/dom-navigation": "^1.0.7",


### PR DESCRIPTION
## Summary
- replace duplicated README workflow badges with a single CI badge pointing to the active workflow
- update npm dependencies via `ncu -u && npm update`
- refresh lockfile to match updated dependency versions

## Validation
- npm run test
- npm run test:e2e (chrome)
- npm run test:e2e:firefox
