### PR TITLE
Fix P2 mutation overhead and auto-detect first-prediction drop

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -523,28 +523,27 @@ async function handleContentScriptPredictReq(
       backgroundServiceWorker.sendCommandToActiveTabContentScript(
         updateLangConfigMessage,
       );
-    } else {
-      const predictRequestMessage: PredictRequestMessage = {
-        command: CMD_BACKGROUND_PAGE_PREDICT_REQ,
-        context: {
-          text: request.context.text,
-          nextChar: request.context.nextChar,
-          lang: language,
-          tabId: sender.tab!.id!,
-          frameId: sender.frameId!,
-          // langName: SUPPORTED_LANGUAGES[language],
-          tributeId: request.context.tributeId,
-          requestId: request.context.requestId,
-        },
-      };
-
-      backgroundServiceWorker.runPrediction(
-        predictRequestMessage,
-        domainSettings.hasNumSuggestionsOverride
-          ? { numSuggestions: domainSettings.numSuggestions }
-          : undefined,
-      );
     }
+    const predictRequestMessage: PredictRequestMessage = {
+      command: CMD_BACKGROUND_PAGE_PREDICT_REQ,
+      context: {
+        text: request.context.text,
+        nextChar: request.context.nextChar,
+        lang: language,
+        tabId: sender.tab!.id!,
+        frameId: sender.frameId!,
+        // langName: SUPPORTED_LANGUAGES[language],
+        tributeId: request.context.tributeId,
+        requestId: request.context.requestId,
+      },
+    };
+
+    backgroundServiceWorker.runPrediction(
+      predictRequestMessage,
+      domainSettings.hasNumSuggestionsOverride
+        ? { numSuggestions: domainSettings.numSuggestions }
+        : undefined,
+    );
   } catch (error) {
     logError("handleContentScriptPredictReq", error);
   }

--- a/src/content-script/DomObserver.ts
+++ b/src/content-script/DomObserver.ts
@@ -15,7 +15,9 @@ export class DomObserver {
   attach() {
     if (!this.observer) {
       this.observer = new MutationObserver((mutationsList) => {
-        setTimeout(() => this.callback(mutationsList), 0);
+        if (mutationsList.length > 0) {
+          this.callback(mutationsList);
+        }
       });
     }
     this.observer.observe(this.node, {

--- a/src/content-script/TributeManager.ts
+++ b/src/content-script/TributeManager.ts
@@ -48,6 +48,7 @@ export class TributeManager {
   private revertOnBackspace: boolean;
   private displayLangHeader: boolean;
   private inline_suggestion: boolean;
+  private helperIdByElement: WeakMap<Element, number>;
   private reTriggerTributeOnReplaceEvent: boolean = false;
   private activeHelperArrId: number | null = null;
 
@@ -95,6 +96,7 @@ export class TributeManager {
     this.revertOnBackspace = revertOnBackspace;
     this.displayLangHeader = displayLangHeader;
     this.inline_suggestion = inline_suggestion;
+    this.helperIdByElement = new WeakMap<Element, number>();
     this.getPrediction = getPrediction; // callback to main class
     this.activeHelperArrId = null;
     console.info(
@@ -169,6 +171,7 @@ export class TributeManager {
       elem: elem,
       requestId: 0,
     } as TributeEntry; // Cast to allow tribute to be added next
+    this.helperIdByElement.set(elem, tributeId);
 
     const tribueKeyFn = this.keys.bind(this);
     const tribueValuesFn = (
@@ -333,6 +336,7 @@ export class TributeManager {
     if (entry.elementKeyDownHandlerRef) {
       elem.removeEventListener("keydown", entry.elementKeyDownHandlerRef);
     }
+    this.helperIdByElement.delete(elem);
     delete this.tributeArr[tributeId];
   }
 
@@ -341,15 +345,16 @@ export class TributeManager {
       this.detachHelper(Number(key));
     }
     this.tributeArr = {};
+    this.helperIdByElement = new WeakMap<Element, number>();
   }
 
   isHelperAttached(elem: Element) {
-    for (const [key] of Object.entries(this.tributeArr)) {
-      if (elem === this.tributeArr[Number(key)].elem) {
-        return true;
-      }
-    }
-    return false;
+    const helperId = this.helperIdByElement.get(elem);
+    return (
+      typeof helperId === "number" &&
+      Boolean(this.tributeArr[helperId]) &&
+      this.tributeArr[helperId].elem === elem
+    );
   }
 
   removeHelpersNotInDocument() {
@@ -442,20 +447,20 @@ export class TributeManager {
       if (propertiesCheck) filteredElems.push(currentElem);
     }
     for (let i = 0; i < filteredElems.length; i++) {
+      if (this.isHelperAttached(filteredElems[i])) continue;
       let skip = false;
       for (const [key] of Object.entries(this.tributeArr)) {
         const keyAsNumber = Number(key);
-        if (filteredElems[i] === this.tributeArr[keyAsNumber].elem) continue;
         if (filteredElems[i].contains(this.tributeArr[keyAsNumber].elem)) {
           this.detachHelper(keyAsNumber);
         } else if (
           this.tributeArr[keyAsNumber].elem.contains(filteredElems[i])
         ) {
           skip = true;
+          break;
         }
       }
       if (skip) continue;
-      if (this.isHelperAttached(filteredElems[i])) continue;
       this.attachHelperToNode(filteredElems[i]);
     }
   }

--- a/src/content-script/content_script.ts
+++ b/src/content-script/content_script.ts
@@ -40,6 +40,9 @@ class FluentTyper {
   // Logging prefix for all logs in this module
   private static readonly LOG_PREFIX = "ContentScript";
   private static readonly WATCHDOG_DEBOUNCE_MS = 250;
+  private static readonly MUTATION_COALESCE_DELAY_MS = 16;
+  private static readonly MAX_MUTATION_BATCH_SIZE = 200;
+  private static readonly MAX_MUTATION_ROOTS = 64;
 
   private readonly SELECTORS: string = "textarea, input, [contentEditable]";
   public tributeManager: TributeManager | null = null;
@@ -61,6 +64,9 @@ class FluentTyper {
   public domObserver: DomObserver;
   private hostName: string = window.location.hostname;
   private watchDogTimeoutId: number | null = null;
+  private mutationProcessTimeoutId: number | null = null;
+  private mutationProcessingScheduled: boolean = false;
+  private pendingMutations: MutationRecord[] = [];
   private rootNodeObserver: MutationObserver | null = null;
   private readonly scheduleWatchDogCheckBound: () => void;
 
@@ -192,6 +198,73 @@ class FluentTyper {
     this.domObserver.attach();
   }
 
+  private getElementDepth(element: Element): number {
+    let depth = 0;
+    let currentNode: Node | null = element;
+    while (currentNode.parentNode) {
+      depth += 1;
+      currentNode = currentNode.parentNode;
+    }
+    return depth;
+  }
+
+  private collectMutationRoots(mutationsList: MutationRecord[]): Element[] {
+    const candidates: Element[] = [];
+    for (const mutation of mutationsList) {
+      mutation.addedNodes.forEach((node) => {
+        if (node instanceof Element && isInDocument(node)) {
+          candidates.push(node);
+        }
+      });
+      if (
+        mutation.type === "attributes" &&
+        mutation.target instanceof Element &&
+        isInDocument(mutation.target)
+      ) {
+        candidates.push(mutation.target);
+      }
+    }
+    if (candidates.length === 0) {
+      return [];
+    }
+
+    const uniqueCandidates = Array.from(new Set(candidates));
+    uniqueCandidates.sort(
+      (left, right) => this.getElementDepth(left) - this.getElementDepth(right),
+    );
+
+    const roots: Element[] = [];
+    for (const candidate of uniqueCandidates) {
+      if (roots.some((root) => root === candidate || root.contains(candidate))) {
+        continue;
+      }
+      for (let i = roots.length - 1; i >= 0; i -= 1) {
+        if (candidate.contains(roots[i])) {
+          roots.splice(i, 1);
+        }
+      }
+      roots.push(candidate);
+    }
+    return roots;
+  }
+
+  private scheduleMutationProcessing(): void {
+    if (this.mutationProcessingScheduled) {
+      return;
+    }
+    this.mutationProcessingScheduled = true;
+    this.mutationProcessTimeoutId = window.setTimeout(() => {
+      this.mutationProcessingScheduled = false;
+      this.mutationProcessTimeoutId = null;
+      const mergedMutations = this.pendingMutations;
+      this.pendingMutations = [];
+      if (!this.enabled || mergedMutations.length === 0) {
+        return;
+      }
+      this.processMutations(mergedMutations);
+    }, FluentTyper.MUTATION_COALESCE_DELAY_MS);
+  }
+
   /**
    * Callback for TributeManager to request predictions.
    */
@@ -257,31 +330,47 @@ class FluentTyper {
       mutationsList.length,
     );
     this.domObserver.disconnect();
-    this.tributeManager?.removeHelpersNotInDocument();
-    for (const mutation of mutationsList) {
-      mutation.addedNodes.forEach((element) => {
-        if (element instanceof Element && isInDocument(element)) {
-          this.tributeManager?.queryAndAttachHelper(element);
-        }
-      });
-      if (mutation.type === "attributes") {
-        if (
-          mutation.target instanceof Element &&
-          isInDocument(mutation.target)
-        ) {
-          this.tributeManager?.queryAndAttachHelper(mutation.target);
-        }
+    try {
+      if (!this.tributeManager) {
+        return;
       }
+      this.tributeManager.removeHelpersNotInDocument();
+
+      if (mutationsList.length >= FluentTyper.MAX_MUTATION_BATCH_SIZE) {
+        this.tributeManager.queryAndAttachHelper();
+        return;
+      }
+
+      const mutationRoots = this.collectMutationRoots(mutationsList);
+      if (mutationRoots.length === 0) {
+        return;
+      }
+
+      if (mutationRoots.length >= FluentTyper.MAX_MUTATION_ROOTS) {
+        this.tributeManager.queryAndAttachHelper();
+        return;
+      }
+
+      for (const mutationRoot of mutationRoots) {
+        this.tributeManager.queryAndAttachHelper(mutationRoot);
+      }
+    } finally {
+      if (this.enabled) {
+        this.attachMutationObserver();
+      }
+      console.groupEnd();
     }
-    this.attachMutationObserver();
-    console.groupEnd();
   }
 
   /**
    * A callback function for the MutationObserver that processes the mutations.
    */
   mutationCallback(mutationsList: MutationRecord[]): void {
-    setTimeout(() => this.processMutations(mutationsList), 0);
+    if (mutationsList.length === 0 || !this.enabled) {
+      return;
+    }
+    this.pendingMutations.push(...mutationsList);
+    this.scheduleMutationProcessing();
   }
 
   /**
@@ -347,6 +436,12 @@ class FluentTyper {
       this.disable.name,
     );
     this.domObserver.disconnect();
+    if (this.mutationProcessTimeoutId !== null) {
+      window.clearTimeout(this.mutationProcessTimeoutId);
+      this.mutationProcessTimeoutId = null;
+    }
+    this.mutationProcessingScheduled = false;
+    this.pendingMutations = [];
     this.tributeManager?.detachAllHelpers();
     console.groupEnd();
   }

--- a/tests/background.routing.test.ts
+++ b/tests/background.routing.test.ts
@@ -450,7 +450,7 @@ describe("background routing and lifecycle", () => {
     );
   });
 
-  test("onMessage requests language update when resolved language differs", async () => {
+  test("onMessage requests language update and still predicts when resolved language differs", async () => {
     const harness = await loadBackgroundHarness();
     harness.state[KEY_LANGUAGE] = "en_US";
 
@@ -458,6 +458,9 @@ describe("background routing and lifecycle", () => {
       harness.module.BackgroundServiceWorker.prototype,
       "sendCommandToActiveTabContentScript",
     );
+    const runPredictionSpy = jest
+      .spyOn(harness.module.BackgroundServiceWorker.prototype, "runPrediction")
+      .mockResolvedValue(undefined);
 
     harness.onMessage(
       {
@@ -479,13 +482,35 @@ describe("background routing and lifecycle", () => {
       command: CMD_BACKGROUND_PAGE_UPDATE_LANG_CONFIG,
       context: { lang: "en_US" },
     });
+    expect(runPredictionSpy).toHaveBeenCalledWith(
+      {
+        command: CMD_BACKGROUND_PAGE_PREDICT_REQ,
+        context: expect.objectContaining({
+          text: "hello",
+          nextChar: "",
+          lang: "en_US",
+          tabId: 2,
+          frameId: 0,
+          tributeId: 1,
+          requestId: 1,
+        }),
+      },
+      undefined,
+    );
   });
 
-  test("onMessage auto-detect branch calls language detector with enabled languages", async () => {
+  test("onMessage auto-detect branch updates language and predicts on first request", async () => {
     const harness = await loadBackgroundHarness({
       language: "auto_detect",
       enabled_languages: ["en_US", "fr_FR"],
     });
+    const sendToActiveSpy = jest.spyOn(
+      harness.module.BackgroundServiceWorker.prototype,
+      "sendCommandToActiveTabContentScript",
+    );
+    const runPredictionSpy = jest
+      .spyOn(harness.module.BackgroundServiceWorker.prototype, "runPrediction")
+      .mockResolvedValue(undefined);
 
     harness.onMessage(
       {
@@ -507,6 +532,25 @@ describe("background routing and lifecycle", () => {
       "en_US",
       "fr_FR",
     ]);
+    expect(sendToActiveSpy).toHaveBeenCalledWith({
+      command: CMD_BACKGROUND_PAGE_UPDATE_LANG_CONFIG,
+      context: { lang: "fr_FR" },
+    });
+    expect(runPredictionSpy).toHaveBeenCalledWith(
+      {
+        command: CMD_BACKGROUND_PAGE_PREDICT_REQ,
+        context: expect.objectContaining({
+          text: "bonjour",
+          nextChar: "",
+          lang: "fr_FR",
+          tabId: 111,
+          frameId: 0,
+          tributeId: 1,
+          requestId: 3,
+        }),
+      },
+      undefined,
+    );
   });
 
   test("onMessage handles options page config change success and failure", async () => {

--- a/tests/content_script.behavior.test.ts
+++ b/tests/content_script.behavior.test.ts
@@ -317,6 +317,61 @@ describe("content_script behavior", () => {
     expect(domObserver.attach).toHaveBeenCalled();
   });
 
+  test("processMutations scans only top-level mutation roots when nodes are nested", async () => {
+    const { fluentTyper, tributeInstances } = await loadContentScript();
+    fluentTyper.enable();
+    const tribute = tributeInstances[0];
+    tribute.queryAndAttachHelper.mockClear();
+
+    const parent = document.createElement("div");
+    const child = document.createElement("span");
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+
+    fluentTyper.processMutations([
+      {
+        type: "childList",
+        addedNodes: [parent] as unknown as NodeList,
+        target: document.body,
+      } as unknown as MutationRecord,
+      {
+        type: "childList",
+        addedNodes: [child] as unknown as NodeList,
+        target: parent,
+      } as unknown as MutationRecord,
+      {
+        type: "attributes",
+        addedNodes: [] as unknown as NodeList,
+        target: child,
+      } as unknown as MutationRecord,
+    ]);
+
+    expect(tribute.queryAndAttachHelper).toHaveBeenCalledTimes(1);
+    expect(tribute.queryAndAttachHelper).toHaveBeenCalledWith(parent);
+  });
+
+  test("processMutations falls back to full scan for very large mutation batches", async () => {
+    const { fluentTyper, tributeInstances } = await loadContentScript();
+    fluentTyper.enable();
+    const tribute = tributeInstances[0];
+    tribute.queryAndAttachHelper.mockClear();
+
+    const largeBatch = Array.from({ length: 200 }, () => {
+      const element = document.createElement("div");
+      document.body.appendChild(element);
+      return {
+        type: "childList",
+        addedNodes: [element] as unknown as NodeList,
+        target: document.body,
+      } as unknown as MutationRecord;
+    });
+
+    fluentTyper.processMutations(largeBatch);
+
+    expect(tribute.queryAndAttachHelper).toHaveBeenCalledTimes(1);
+    expect(tribute.queryAndAttachHelper).toHaveBeenCalledWith();
+  });
+
   test("watchdog checks host/domain changes and restarts on node replacement", async () => {
     const { fluentTyper, domObserverInstances, sendMessage } =
       await loadContentScript();


### PR DESCRIPTION
## Summary
- Coalesce content-script mutation observer events and process them in bounded batches.
- Deduplicate nested mutation roots and fall back to one full scan under heavy mutation bursts.
- Reduce helper attach lookup overhead in `TributeManager` via element-to-helper indexing.
- Preserve same-keystroke prediction when language is auto-detected and differs from content-script state.
- Add regression tests for nested/large mutation batches and mismatch + auto-detect prediction flow.

## Files Changed
- `src/content-script/DomObserver.ts`
- `src/content-script/content_script.ts`
- `src/content-script/TributeManager.ts`
- `src/background/background.ts`
- `tests/content_script.behavior.test.ts`
- `tests/background.routing.test.ts`

## Validation
- `npm test -- tests/content_script.behavior.test.ts`
- `npm test -- tests/content_script.watchdog.test.ts`
- `npm test -- tests/background.routing.test.ts`
- `npx eslint src/content-script/DomObserver.ts src/content-script/content_script.ts src/content-script/TributeManager.ts src/background/background.ts tests/content_script.behavior.test.ts tests/background.routing.test.ts`