### PR TITLE
test: fix flaky content script mutation tests

### DIFF
--- a/src/adapters/chrome/content-script/HostChangeWatcher.ts
+++ b/src/adapters/chrome/content-script/HostChangeWatcher.ts
@@ -32,6 +32,18 @@ export class HostChangeWatcher {
     this.scheduleWatchDogCheck();
   }
 
+  stop(): void {
+    if (this.watchDogTimeoutId !== null) {
+      window.clearTimeout(this.watchDogTimeoutId);
+      this.watchDogTimeoutId = null;
+    }
+    if (this.rootNodeObserver) {
+      this.rootNodeObserver.disconnect();
+      this.rootNodeObserver = null;
+    }
+    this.detachWatchDogEventListeners();
+  }
+
   getHostName(): string {
     return this.stateMachine.getHostName();
   }
@@ -113,5 +125,15 @@ export class HostChangeWatcher {
     window.addEventListener("focus", this.scheduleWatchDogCheckBound, true);
     document.addEventListener("visibilitychange", this.scheduleWatchDogCheckBound);
     document.addEventListener("readystatechange", this.scheduleWatchDogCheckBound);
+  }
+
+  private detachWatchDogEventListeners(): void {
+    window.navigation?.removeEventListener("navigate", this.scheduleWatchDogCheckBound);
+    window.removeEventListener("pageshow", this.scheduleWatchDogCheckBound);
+    window.removeEventListener("popstate", this.scheduleWatchDogCheckBound);
+    window.removeEventListener("hashchange", this.scheduleWatchDogCheckBound);
+    window.removeEventListener("focus", this.scheduleWatchDogCheckBound, true);
+    document.removeEventListener("visibilitychange", this.scheduleWatchDogCheckBound);
+    document.removeEventListener("readystatechange", this.scheduleWatchDogCheckBound);
   }
 }

--- a/src/adapters/chrome/content-script/content_script.ts
+++ b/src/adapters/chrome/content-script/content_script.ts
@@ -26,6 +26,11 @@ class FluentTyper {
   private readonly runtimeController: ContentRuntimeController;
   private readonly contentMessageHandler: ContentMessageHandler;
   private readonly hostChangeWatcher: HostChangeWatcher;
+  private readonly boundMessageHandler = (
+    message: Message | null,
+    sender?: chrome.runtime.MessageSender,
+    sendResponse?: (response: unknown) => void,
+  ) => this.messageHandler(message, sender, sendResponse);
 
   constructor() {
     logger.info("Initializing content script", {
@@ -63,7 +68,7 @@ class FluentTyper {
       requestConfig: () => this.getConfig(),
     });
 
-    chrome.runtime.onMessage.addListener(this.messageHandler.bind(this));
+    chrome.runtime.onMessage.addListener(this.boundMessageHandler);
     this.hostChangeWatcher.start();
     this.getConfig();
   }
@@ -134,6 +139,13 @@ class FluentTyper {
 
   restart(): void {
     this.runtimeController.restart();
+  }
+
+  destroy(): void {
+    logger.info("Destroying content script instance");
+    this.hostChangeWatcher.stop();
+    this.disable();
+    chrome.runtime.onMessage.removeListener(this.boundMessageHandler);
   }
 
   messageHandler(

--- a/tests/content_script.behavior.test.ts
+++ b/tests/content_script.behavior.test.ts
@@ -48,6 +48,7 @@ type LoadedContentScript = {
     enable: () => void;
     disable: () => void;
     restart: () => void;
+    destroy: () => void;
   };
   tributeInstances: TributeLike[];
   domObserverInstances: DomObserverLike[];
@@ -80,6 +81,7 @@ function defaultConfig(overrides: Record<string, unknown> = {}) {
 }
 
 const behaviorHarness = {
+  fluentTyperInstances: [] as LoadedContentScript["fluentTyper"][],
   tributeInstances: [] as TributeLike[],
   domObserverInstances: [] as DomObserverLike[],
   checkLastError: jest.fn(),
@@ -134,7 +136,10 @@ async function loadContentScript(): Promise<LoadedContentScript> {
 
   (globalThis as unknown as { chrome: unknown }).chrome = {
     runtime: {
-      onMessage: { addListener: jest.fn() },
+      onMessage: {
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      },
       sendMessage: behaviorHarness.sendMessage,
     },
   };
@@ -143,6 +148,8 @@ async function loadContentScript(): Promise<LoadedContentScript> {
   await import(freshModulePath("../src/adapters/chrome/content-script/content_script"));
   const fluentTyper = (window as Window & { FluentTyper?: LoadedContentScript["fluentTyper"] })
     .FluentTyper!;
+
+  behaviorHarness.fluentTyperInstances.push(fluentTyper);
 
   return {
     fluentTyper,
@@ -154,6 +161,14 @@ async function loadContentScript(): Promise<LoadedContentScript> {
 }
 
 describe("content_script behavior", () => {
+  afterEach(() => {
+    for (const fluentTyper of behaviorHarness.fluentTyperInstances) {
+      fluentTyper.destroy();
+    }
+    behaviorHarness.fluentTyperInstances.length = 0;
+    document.body.innerHTML = "";
+  });
+
   afterAll(() => {
     mock.restore();
   });


### PR DESCRIPTION
Fixes a flaky mutation test by clearing FluentTyper instances and HostChangeWatcher timeouts between test runs. This issue was caused by the test harness leaving behind timeouts that could unexpectedly trigger and destroy the TributeManager during subsequent parallel tests.