### PR TITLE
fix(tooling): support bun pm version bumping directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
     "test:e2e:dev": "bun scripts/run-e2e.ts --mode=development",
     "update": "bun update --latest --recursive",
     "preversion": "bun run test",
-    "version": "bun scripts/update-manifest-version.cjs",
-    "postversion": "git push && git push --tags",
+    "version": "echo 'version updated'",
+    "postversion": "bun scripts/update-manifest-version.cjs && git push && git push --tags",
     "lint:fix": "bun run lint -- --fix",
     "fix": "bun run lint:fix && bun run format",
     "format": "prettier . --cache --write",
-    "format:check": "prettier . --cache --check"
+    "format:check": "prettier . --cache --check",
+    "bump": "bun pm version"
   },
   "repository": {
     "type": "git",

--- a/scripts/update-manifest-version.cjs
+++ b/scripts/update-manifest-version.cjs
@@ -29,6 +29,7 @@ manifests.forEach((manifestPath) => {
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
   manifest.version = version;
   fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  execSync(`bun run prettier --write "${manifestPath}"`, { stdio: "inherit" });
   execSync(`git add "${manifestPath}"`);
 });
 


### PR DESCRIPTION
## Description
Fixes an issue where \`bun version\` did not properly bump the \`package.json\` version and caused the \`scripts/update-manifest-version.cjs\` script to break the \`manifest.json\` formatting due to missing Prettier usage.

- **package.json**: Replaces the \`version\` script hack with a native \`bump: bun pm version\` alias, while moving actual manifest modification to the \`postversion\` lifecycle script exactly where it belongs.
- **scripts/update-manifest-version.cjs**: Prettifies \`manifest.json\` right before committing it, to stop large trailing line diffs on array properties.