### PR TITLE
fix: make watch script respect development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "bun@1.3.10",
   "scripts": {
-    "watch": "bun run build --mode=development --watch",
+    "watch": "bun build.ts --mode=development --watch",
     "build": "bun build.ts --mode=production",
     "check": "bun run lint && bun run format:check",
     "lint": "eslint . --cache --cache-location .cache/eslint --max-warnings=0",


### PR DESCRIPTION
## Summary
- update the watch script to pass development mode correctly to the Bun build entry
- ensures iterative local development runs with dev configuration instead of production defaults

## Validation
- script-level change; validated command wiring by inspection