### PR TITLE
docs: add and refine AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,13 @@ If you’re an agent: follow the guardrails below, prefer small focused changes,
 ## “Golden” commands (run these)
 
 ### Install
+
 ```bash
 bun install
 ```
 
 ### Build
+
 ```bash
 bun run build
 # Build Firefox:
@@ -41,11 +43,13 @@ bun run build --platform=firefox
 ```
 
 ### Watch mode (iterative dev)
+
 ```bash
 bun run watch
 ```
 
 ### Quality gates (before PR)
+
 ```bash
 bun run check
 bun run test
@@ -56,6 +60,7 @@ bun run test:e2e:dev
 ```
 
 ### Autofix
+
 ```bash
 bun run fix
 ```
@@ -76,12 +81,14 @@ bun run fix
 ## Repository map (where things live)
 
 ### Entry points (bundled)
+
 - `src/entries/background.ts` → background bootstrap
 - `src/entries/content_script.ts` → content-script bootstrap
 - `src/entries/popup.ts` → popup UI bootstrap
 - `src/entries/settings.ts` → options/settings bootstrap
 
 ### Layered architecture
+
 - `src/core/domain/`  
   Contracts, types, constants, pure logic. **No imports from application/adapters/ui**.
 - `src/core/application/`  
@@ -94,9 +101,11 @@ bun run fix
   Popup + options UI.
 
 ### Path aliases (use these)
+
 - `@core/*`, `@adapters/*`, `@ui/*`, `@third-party/*`
 
 Avoid legacy import roots like:
+
 - `src/background/*`, `src/content-script/*`, `src/shared/*`
 
 ---
@@ -113,6 +122,7 @@ Follow these boundaries when adding/changing code:
 - `src/ui`: UI only; do not reach into adapter internals.
 
 If you need a cross-layer contract, put it in:
+
 - `src/core/domain/contracts/**` and/or `src/core/domain/messageTypes.d.ts`
 
 ---
@@ -127,6 +137,7 @@ High level flow:
 4. Content script renders suggestions + handles acceptance (Tab/keyboard navigation).
 
 If you change message shapes:
+
 - Update `src/core/domain/messageTypes.d.ts`
 - Update constants in `src/core/domain/constants.ts`
 - Update routers/handlers in `src/adapters/chrome/background/router/**`
@@ -140,6 +151,7 @@ If you change message shapes:
 - Dev/debug builds can include WebLLM and will adjust CSP/connect-src accordingly during build.
 
 When touching this area:
+
 - Do not make WebLLM required for normal operation.
 - Keep safe fallbacks when the AI predictor is unavailable or times out.
 - Avoid increasing network surface area in production builds.
@@ -151,10 +163,12 @@ When touching this area:
 Text expansion is configured via settings and used in prediction + expansion logic.
 
 Dynamic variables are resolved in:
+
 - `src/core/domain/variables.ts` (e.g. `${time}`, `${date}`, `${datetime}`, `${uuid}`, `${random:...}`)
 - `src/adapters/chrome/background/TemplateExpander.ts` (async resolver; can also read active tab context for page variables)
 
 If you add a new variable:
+
 1. Add it to `resolveDynamicVariable(...)` in `src/core/domain/variables.ts` when it can be computed locally.
 2. If it needs browser context (tab/title/url), extend the resolver in `TemplateExpander.createResolver(...)`.
 3. Add/adjust tests if behavior changes.
@@ -164,6 +178,7 @@ If you add a new variable:
 ## Settings changes (how to do it safely)
 
 When adding a new user-facing setting:
+
 - Add a key/constant in `src/core/domain/constants.ts` (if it’s used in runtime logic).
 - Wire it through repositories (likely `src/core/application/repositories/**`).
 - Ensure config assembly includes it if it affects runtime (`src/adapters/chrome/background/config/ConfigAssembler.ts`).
@@ -176,11 +191,13 @@ Keep backward compatibility in mind; migrations exist for older stored settings.
 ## Platform manifests + versioning
 
 Manifests live under:
+
 - `platform/chrome/manifest.json`
 - `platform/firefox/manifest.json`
 - `platform/edge/manifest.json`
 
 Versioning workflow:
+
 - `package.json` is the source of truth for the version.
 - `bun version` runs `scripts/update-manifest-version.cjs` to sync manifest versions.
 
@@ -208,6 +225,7 @@ Do not hand-edit versions in multiple places without running the script.
 ## If you’re unsure
 
 Prefer:
+
 - Small, reversible changes
 - Adding tests
 - Keeping behavior consistent with README/Contributing docs


### PR DESCRIPTION
## Summary
- add AGENTS.md guidance for AI coding contributors
- correct Firefox build/load instructions
- explicitly require e2e in quality gate guidance

## Validation
- docs-only change