### PR TITLE
Fix Slack manual attach icon stability and dark-theme contrast

### DIFF
--- a/src/adapters/chrome/content-script/suggestions/ManualAttachUiManager.ts
+++ b/src/adapters/chrome/content-script/suggestions/ManualAttachUiManager.ts
@@ -455,10 +455,24 @@ export class ManualAttachUiManager {
 
   private collectAncestorElements(element: ManualAttachTarget): HTMLElement[] {
     const ancestors: HTMLElement[] = [];
-    let current = element.parentElement;
+    let current: HTMLElement | null = element;
     while (current) {
-      ancestors.push(current);
-      current = current.parentElement;
+      const parentElement = current.parentElement;
+      if (this.isHtmlElement(parentElement, current.ownerDocument)) {
+        ancestors.push(parentElement);
+        current = parentElement;
+        continue;
+      }
+      const rootNode = current.getRootNode();
+      if (
+        this.isShadowRoot(rootNode, current.ownerDocument) &&
+        this.isHtmlElement(rootNode.host, current.ownerDocument)
+      ) {
+        ancestors.push(rootNode.host);
+        current = rootNode.host;
+        continue;
+      }
+      current = null;
     }
     const body = element.ownerDocument.body;
     if (body && !ancestors.includes(body)) {

--- a/tests/SuggestionManagerRuntime.test.ts
+++ b/tests/SuggestionManagerRuntime.test.ts
@@ -1610,6 +1610,26 @@ describe("SuggestionManagerRuntime", () => {
       expect(getManualAttachButton(host)).toBeNull();
     });
 
+    test("uses dark surface styling for a shadow-hosted conflicting field on a dark host", () => {
+      const runtime = makeRuntime();
+      const host = document.createElement("div");
+      host.style.backgroundColor = "rgb(29, 28, 29)";
+      document.body.appendChild(host);
+      const shadow = host.attachShadow({ mode: "open" });
+      const list = document.createElement("datalist");
+      list.id = "cities";
+      const shadowInput = document.createElement("input");
+      shadowInput.type = "text";
+      shadowInput.setAttribute("list", "cities");
+      shadow.append(list, shadowInput);
+
+      runtime.queryAndAttachHelper();
+
+      const button = getManualAttachButton(shadow);
+      expect(button).not.toBeNull();
+      expect(button?.style.backgroundColor).toBe("rgba(15, 23, 42, 0.92)");
+    });
+
     test("removes the manual attach icon when a shadow-hosted conflicting field is removed", () => {
       const runtime = makeRuntime();
       const host = document.createElement("div");


### PR DESCRIPTION
## Summary
- stop the manual attach icon from jumping around in complex editors like Slack by only treating real peer controls as placement obstacles
- make the manual attach icon theme-aware so it uses a high-contrast dark-surface treatment instead of the washed-out light chip on Slack dark theme
- add regression coverage for the Slack-like layout case and the dark-surface styling case

## Testing
- bun test tests/SuggestionManagerRuntime.test.ts
- bun test tests/NativeAutocompleteConflictDetector.test.ts
- bun run lint src/adapters/chrome/content-script/suggestions/ManualAttachUiManager.ts tests/SuggestionManagerRuntime.test.ts
- bun run format:check src/adapters/chrome/content-script/suggestions/ManualAttachUiManager.ts tests/SuggestionManagerRuntime.test.ts