### PR TITLE
Fix CKEditor Firefox capitalization regression

### DIFF
--- a/src/adapters/chrome/content-script/suggestions/HostEditorAdapterResolver.ts
+++ b/src/adapters/chrome/content-script/suggestions/HostEditorAdapterResolver.ts
@@ -27,6 +27,14 @@ export interface HostEditorSession {
     replaceEnd: number;
     replacementText: string;
     cursorAfter: number;
+    /**
+     * The caller's view of the block text (pre-edit).  When omitted,
+     * the session uses the block text captured at resolve time.  Pass
+     * this explicitly when the extension's DOM view may diverge from
+     * the host model (e.g. Firefox CKEditor-5 lag) so the bridge can
+     * decide whether to apply an incremental edit or rewrite the block.
+     */
+    expectedBlockText?: string;
   }): HostEditorApplyResult;
   createPostEditFingerprint(): PostEditFingerprint;
 }
@@ -108,18 +116,20 @@ class BridgedLineEditorHostSession implements HostEditorSession {
     replaceEnd,
     replacementText,
     cursorAfter,
+    expectedBlockText,
   }: {
     replaceStart: number;
     replaceEnd: number;
     replacementText: string;
     cursorAfter: number;
+    expectedBlockText?: string;
   }): HostEditorApplyResult {
     return this.pageBridge.applyBlockReplacement(this.elem, {
       replaceStart,
       replaceEnd,
       replacementText,
       cursorAfter,
-      expectedBlockText: this.expectedBlockText,
+      expectedBlockText: expectedBlockText ?? this.expectedBlockText,
     });
   }
 
@@ -150,7 +160,11 @@ class LineEditorHostSession implements HostEditorSession {
     replaceEnd: number;
     replacementText: string;
     cursorAfter: number;
+    expectedBlockText?: string;
   }): HostEditorApplyResult {
+    // LineEditor host (CodeMirror) owns both its DOM and its model, so
+    // there is no staleness window and we ignore the caller's
+    // expectedBlockText hint.
     const cursor = this.readCursor();
     if (!cursor) {
       return { applied: false, didDispatchInput: false };

--- a/src/adapters/chrome/content-script/suggestions/HostEditorMainWorldBridge.ts
+++ b/src/adapters/chrome/content-script/suggestions/HostEditorMainWorldBridge.ts
@@ -44,8 +44,14 @@ interface CKEditorEditingViewDomConverter {
   domPositionToView(domParent: Node, domOffset?: number): any;
 }
 
+interface CKEditorViewObserver {
+  flush?: () => void;
+  _mutationObserver?: unknown;
+}
+
 interface CKEditorEditingView {
   domConverter?: CKEditorEditingViewDomConverter;
+  _observers?: Map<unknown, CKEditorViewObserver>;
 }
 
 interface CKEditorEditingMapper {
@@ -221,6 +227,10 @@ function getCKEditor5SelectionPosition(editor: CKEditorInstance): any {
 function getCKEditor5BlockContext(
   editor: CKEditorInstance,
 ): { beforeCursor: string; afterCursor: string; blockText: string } | null {
+  // Drain any pending DOM mutation records so the returned block text
+  // reflects what the user sees in the DOM, not a stale model snapshot
+  // (Firefox CKEditor-5 may briefly lag by one character after typing).
+  flushCKEditor5PendingMutations(editor);
   const position = getCKEditor5SelectionPosition(editor);
   if (!position) {
     return null;
@@ -247,10 +257,42 @@ function getCKEditor5BlockContext(
   };
 }
 
+/**
+ * Synchronously drain any pending DOM mutation records that CKEditor-5's
+ * MutationObserver has queued but not yet reconciled into the model.  On
+ * Firefox, a character typed into the DOM can sit in this queue briefly
+ * while the observer's microtask is still pending.  Flushing here before we
+ * read or write the model ensures we operate on a state that agrees with
+ * what the user sees in the DOM.
+ */
+function flushCKEditor5PendingMutations(editor: CKEditorInstance): void {
+  const observers = editor.editing?.view?._observers;
+  if (!observers || typeof observers.values !== "function") {
+    return;
+  }
+  for (const observer of observers.values()) {
+    // The MutationObserver wrapper is the only observer that owns a
+    // native `_mutationObserver` instance.  Its `flush()` synchronously
+    // processes any pending records and reconciles them into the model.
+    if (observer && observer._mutationObserver && typeof observer.flush === "function") {
+      try {
+        observer.flush();
+      } catch {
+        // Best-effort: if flushing throws, proceed without it.
+      }
+      return;
+    }
+  }
+}
+
 function applyCKEditor5BlockReplacement(
   editor: CKEditorInstance,
   request: Extract<BridgeRequest, { action: "applyBlockReplacement" }>,
 ): { applied: boolean; didDispatchInput: boolean } {
+  // Drain any pending DOM mutation records before reading the model so that
+  // a freshly-typed character already in the DOM (Firefox CKEditor-5 lag)
+  // is reflected in the model we plan to edit.
+  flushCKEditor5PendingMutations(editor);
   const position = getCKEditor5SelectionPosition(editor);
   if (!position) {
     return { applied: false, didDispatchInput: false };

--- a/src/adapters/chrome/content-script/suggestions/HostEditorMainWorldBridge.ts
+++ b/src/adapters/chrome/content-script/suggestions/HostEditorMainWorldBridge.ts
@@ -40,8 +40,39 @@ interface CKEditorModel {
   change(callback: (writer: any) => void): void;
 }
 
+interface CKEditorEditingViewDomConverter {
+  domPositionToView(domParent: Node, domOffset?: number): any;
+}
+
+interface CKEditorEditingView {
+  domConverter?: CKEditorEditingViewDomConverter;
+}
+
+interface CKEditorEditingMapper {
+  toModelPosition(viewPosition: any): any;
+}
+
+interface CKEditorEditing {
+  mapper?: CKEditorEditingMapper;
+  view?: CKEditorEditingView;
+}
+
+interface CKEditorUiEditable {
+  element?: HTMLElement | null;
+}
+
+interface CKEditorUiView {
+  editable?: CKEditorUiEditable;
+}
+
+interface CKEditorUi {
+  view?: CKEditorUiView;
+}
+
 interface CKEditorInstance {
   model: CKEditorModel;
+  editing?: CKEditorEditing;
+  ui?: CKEditorUi;
 }
 
 const ckEditorInstanceCache = new WeakMap<HTMLElement, CKEditorInstance | null>();
@@ -150,10 +181,47 @@ function modelOffsetToTextOffset(modelOffset: number, softBreakModelOffsets: num
   return modelOffset - adjustment;
 }
 
+function getCKEditorEditableElement(editor: CKEditorInstance): HTMLElement | null {
+  const editable = editor.ui?.view?.editable?.element;
+  return editable instanceof HTMLElement ? editable : null;
+}
+
+function getCKEditor5SelectionPosition(editor: CKEditorInstance): any {
+  const editable = getCKEditorEditableElement(editor);
+  const domSelection = document.getSelection();
+  if (
+    editable &&
+    domSelection &&
+    domSelection.rangeCount > 0 &&
+    typeof editor.editing?.view?.domConverter?.domPositionToView === "function" &&
+    typeof editor.editing?.mapper?.toModelPosition === "function"
+  ) {
+    try {
+      const range = domSelection.getRangeAt(0);
+      if (editable === range.startContainer || editable.contains(range.startContainer)) {
+        const viewPosition = editor.editing.view.domConverter.domPositionToView(
+          range.startContainer,
+          range.startOffset,
+        );
+        if (viewPosition) {
+          const modelPosition = editor.editing.mapper.toModelPosition(viewPosition);
+          if (modelPosition) {
+            return modelPosition;
+          }
+        }
+      }
+    } catch {
+      // Fall through to CKEditor's current model selection.
+    }
+  }
+
+  return editor.model.document.selection.getFirstPosition();
+}
+
 function getCKEditor5BlockContext(
   editor: CKEditorInstance,
 ): { beforeCursor: string; afterCursor: string; blockText: string } | null {
-  const position = editor.model.document.selection.getFirstPosition();
+  const position = getCKEditor5SelectionPosition(editor);
   if (!position) {
     return null;
   }
@@ -183,7 +251,7 @@ function applyCKEditor5BlockReplacement(
   editor: CKEditorInstance,
   request: Extract<BridgeRequest, { action: "applyBlockReplacement" }>,
 ): { applied: boolean; didDispatchInput: boolean } {
-  const position = editor.model.document.selection.getFirstPosition();
+  const position = getCKEditor5SelectionPosition(editor);
   if (!position) {
     return { applied: false, didDispatchInput: false };
   }
@@ -242,7 +310,7 @@ function applyCKEditor5BlockReplacement(
   // the inserted text preserves the surrounding formatting.
   let textAttrs: Record<string, unknown> | null = null;
   try {
-    const probePos = editor.model.document.selection.getFirstPosition();
+    const probePos = position;
     if (probePos) {
       const node = probePos.textNode ?? probePos.nodeBefore ?? probePos.nodeAfter;
       if (node && typeof node.getAttributes === "function") {

--- a/src/adapters/chrome/content-script/suggestions/HostEditorMainWorldBridge.ts
+++ b/src/adapters/chrome/content-script/suggestions/HostEditorMainWorldBridge.ts
@@ -260,21 +260,62 @@ function applyCKEditor5BlockReplacement(
     return { applied: false, didDispatchInput: false };
   }
   const mapping = extractModelBlockMapping(block);
+  if (mapping === null) {
+    return { applied: false, didDispatchInput: false };
+  }
+  // Validate the request bounds against the caller's view of the block,
+  // not the host model.  When the host is lagging (Firefox can expose a
+  // newly typed character in the DOM before CKEditor's model observes
+  // it) the caller's view is the authoritative pre-edit state.
   if (
-    mapping === null ||
-    mapping.text !== request.expectedBlockText ||
     request.replaceStart < 0 ||
     request.replaceEnd < request.replaceStart ||
-    request.replaceEnd > mapping.text.length
+    request.replaceEnd > request.expectedBlockText.length
   ) {
     return { applied: false, didDispatchInput: false };
   }
   const expectedLength =
-    mapping.text.length -
+    request.expectedBlockText.length -
     (request.replaceEnd - request.replaceStart) +
     request.replacementText.length;
   if (request.cursorAfter < 0 || request.cursorAfter > expectedLength) {
     return { applied: false, didDispatchInput: false };
+  }
+
+  if (mapping.text !== request.expectedBlockText) {
+    // Host model is stale relative to the caller's view.  Only take the
+    // rewrite path when the mismatch looks like a Firefox CKEditor-5
+    // "typed char not yet observed" lag: the host model should look
+    // exactly like the caller's pre-edit view with the character(s) the
+    // caller is about to replace removed.  This both avoids losing
+    // softBreaks (which we don't attempt to rewrite) and guards against
+    // unrelated mismatches corrupting the block.
+    if (mapping.softBreakModelOffsets.length > 0) {
+      return { applied: false, didDispatchInput: false };
+    }
+    const expectedMissingLeading =
+      request.expectedBlockText.slice(0, request.replaceStart) +
+      request.expectedBlockText.slice(request.replaceEnd);
+    if (mapping.text !== expectedMissingLeading) {
+      return { applied: false, didDispatchInput: false };
+    }
+    const expectedPostEditText =
+      request.expectedBlockText.slice(0, request.replaceStart) +
+      request.replacementText +
+      request.expectedBlockText.slice(request.replaceEnd);
+    try {
+      editor.model.change((writer: any) => {
+        writer.remove(writer.createRangeIn(block));
+        if (expectedPostEditText.length > 0) {
+          writer.insertText(expectedPostEditText, writer.createPositionAt(block, 0));
+        }
+        const cursorPos = writer.createPositionAt(block, request.cursorAfter);
+        writer.setSelection(cursorPos);
+      });
+    } catch {
+      return { applied: false, didDispatchInput: false };
+    }
+    return { applied: true, didDispatchInput: false };
   }
 
   // Translate text offsets to model offsets (accounting for softBreaks).

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -788,6 +788,14 @@ export class SuggestionTextEditService {
       source: "grammar",
       sourceRuleId: edit.sourceRuleId,
     };
+    if (!TextTargetAdapter.isTextValue(entry.elem)) {
+      this.scheduleDeferredContentEditableGrammarValidation(entry, {
+        expectedFullText,
+        expectedCursorAfter: cursorAfter,
+        expectedBlockText,
+        expectedBlockCursorAfter,
+      });
+    }
     return {
       applied: true,
       didDispatchInput: finalApplyResult.didDispatchInput,
@@ -1715,6 +1723,67 @@ export class SuggestionTextEditService {
       applyResult,
       postEditSnapshot: TextTargetAdapter.snapshot(elem as TextTarget),
     };
+  }
+
+  private scheduleDeferredContentEditableGrammarValidation(
+    entry: SuggestionEntry,
+    {
+      expectedFullText,
+      expectedCursorAfter,
+      expectedBlockText,
+      expectedBlockCursorAfter,
+    }: {
+      expectedFullText: string;
+      expectedCursorAfter: number;
+      expectedBlockText: string | null;
+      expectedBlockCursorAfter: number | null;
+    },
+  ): void {
+    const elem = entry.elem;
+    if (TextTargetAdapter.isTextValue(elem)) {
+      return;
+    }
+
+    let applied = false;
+    const validate = () => {
+      if (applied || !elem.isConnected || entry.pendingExtensionEdit?.source !== "grammar") {
+        return;
+      }
+      const currentSnapshot = TextTargetAdapter.snapshot(elem as TextTarget);
+      if (
+        this.matchesExpectedGrammarResult(currentSnapshot, expectedFullText, expectedCursorAfter)
+      ) {
+        return;
+      }
+
+      const corrected = this.correctContentEditableGrammarMismatch(entry, {
+        expectedFullText,
+        expectedCursorAfter,
+        expectedBlockText,
+        expectedBlockCursorAfter,
+      });
+      if (!corrected) {
+        return;
+      }
+
+      applied = true;
+      this.domPreferredGrammarTargets.add(elem as HTMLElement);
+      if (entry.pendingExtensionEdit) {
+        entry.pendingExtensionEdit.cursorAfter = corrected.postEditSnapshot.cursorOffset;
+        entry.pendingExtensionEdit.postEditFingerprint =
+          TextTargetAdapter.createPostEditFingerprint(
+            elem as TextTarget,
+            corrected.postEditSnapshot,
+          );
+      }
+    };
+
+    if (typeof globalThis.requestAnimationFrame === "function") {
+      globalThis.requestAnimationFrame(validate);
+    } else {
+      setTimeout(validate, 0);
+    }
+    setTimeout(validate, 30);
   }
 
   private dispatchInputEvent(elem: SuggestionElement): void {

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -805,6 +805,7 @@ export class SuggestionTextEditService {
         expectedCursorAfter: cursorAfter,
         expectedBlockText,
         expectedBlockCursorAfter,
+        originalText,
       });
     }
     return {
@@ -1142,6 +1143,20 @@ export class SuggestionTextEditService {
       `${snapshot.beforeCursor}${snapshot.afterCursor}` === expectedFullText &&
       snapshot.cursorOffset === expectedCursorAfter
     );
+  }
+
+  private isLikelyLateHostGrammarEcho(
+    snapshot: SuggestionSnapshot,
+    expectedFullText: string,
+    expectedCursorAfter: number,
+    originalText: string,
+  ): boolean {
+    if (originalText.length === 0) {
+      return false;
+    }
+    const currentFullText = `${snapshot.beforeCursor}${snapshot.afterCursor}`;
+    const echoedFullText = `${expectedFullText.slice(0, expectedCursorAfter)}${originalText}${expectedFullText.slice(expectedCursorAfter)}`;
+    return currentFullText === echoedFullText;
   }
 
   /**
@@ -1743,11 +1758,13 @@ export class SuggestionTextEditService {
       expectedCursorAfter,
       expectedBlockText,
       expectedBlockCursorAfter,
+      originalText,
     }: {
       expectedFullText: string;
       expectedCursorAfter: number;
       expectedBlockText: string | null;
       expectedBlockCursorAfter: number | null;
+      originalText: string;
     },
   ): void {
     const elem = entry.elem;
@@ -1757,13 +1774,24 @@ export class SuggestionTextEditService {
 
     let applied = false;
     const validate = () => {
-      if (applied || !elem.isConnected || entry.pendingExtensionEdit?.source !== "grammar") {
+      if (applied || !elem.isConnected) {
         return;
       }
       const currentSnapshot = TextTargetAdapter.snapshot(elem as TextTarget);
       if (
         this.matchesExpectedGrammarResult(currentSnapshot, expectedFullText, expectedCursorAfter)
       ) {
+        return;
+      }
+      const shouldRepairMismatch =
+        entry.pendingExtensionEdit?.source === "grammar" ||
+        this.isLikelyLateHostGrammarEcho(
+          currentSnapshot,
+          expectedFullText,
+          expectedCursorAfter,
+          originalText,
+        );
+      if (!shouldRepairMismatch) {
         return;
       }
 

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -652,22 +652,26 @@ export class SuggestionTextEditService {
             blockCursorAfter,
           );
         }
+        if (applyResult === null) {
+          // Last-resort host path for hosts whose model lags the DOM
+          // (Firefox CKEditor-5 can expose a newly typed character in
+          // the DOM before its model observes it).  Bypass the parity
+          // check and hand the request to the bridge, which will
+          // rewrite the block through the editor's own model API so
+          // CKEditor reconciles through its normal rendering pipeline
+          // instead of racing against a foreign DOM mutation.
+          applyResult = this.tryHostGrammarEditWithStaleHostRewrite(
+            entry.elem as HTMLElement,
+            blockSourceText,
+            blockReplaceStart,
+            blockReplaceEnd,
+            replacement,
+            blockCursorAfter,
+          );
+        }
       }
     }
     if (applyResult === null) {
-      // When every host-editor path above failed, the host's model state
-      // is inconsistent with the DOM view the extension built its edit
-      // from (e.g. Firefox CKEditor-5 hasn't yet synced the character the
-      // user just typed).  In that situation routing the fallback through
-      // beforeinput/execCommand re-enters the host's stale model and
-      // produces a duplicated character.  Force a direct DOM mutation
-      // instead so the host's MutationObserver sees a single clean diff
-      // and reconciles its model in one step.
-      const hostAdapterPresent =
-        !TextTargetAdapter.isTextValue(entry.elem) &&
-        this.hostEditorAdapterResolver.resolve(entry.elem as HTMLElement) !== null;
-      const preferDomMutation =
-        this.shouldPreferDomMutationForGrammar(entry.elem) || hostAdapterPresent;
       applyResult =
         !TextTargetAdapter.isTextValue(entry.elem) &&
         activeBlock !== null &&
@@ -682,7 +686,7 @@ export class SuggestionTextEditService {
               replacement,
               blockCursorAfter,
               {
-                preferDomMutation,
+                preferDomMutation: this.shouldPreferDomMutationForGrammar(entry.elem),
                 scopeRoot: activeBlock,
               },
             )
@@ -693,7 +697,7 @@ export class SuggestionTextEditService {
               replaceEnd,
               replacement,
               cursorAfter,
-              { preferDomMutation },
+              { preferDomMutation: this.shouldPreferDomMutationForGrammar(entry.elem) },
             );
     }
     // For edits with cursorOffset on contenteditable, schedule deferred cursor
@@ -1199,6 +1203,38 @@ export class SuggestionTextEditService {
       replaceEnd: fullReplaceEnd,
       replacementText,
       cursorAfter: fullCursorAfter,
+    });
+    if (!hostResult.applied) {
+      return null;
+    }
+    return {
+      didMutateDom: true,
+      didDispatchInput: hostResult.didDispatchInput,
+    };
+  }
+
+  private tryHostGrammarEditWithStaleHostRewrite(
+    elem: HTMLElement,
+    blockText: string,
+    replaceStart: number,
+    replaceEnd: number,
+    replacementText: string,
+    cursorAfter: number,
+  ): { didMutateDom: boolean; didDispatchInput: boolean } | null {
+    const session = this.hostEditorAdapterResolver.resolve(elem);
+    if (!session) {
+      return null;
+    }
+    // The bridge validates request bounds against the expected block
+    // text and, when its model is stale, rewrites the block by
+    // replacing its content with the post-edit text via the editor's
+    // own model API.  We therefore don't need a parity check here.
+    const hostResult = session.applyBlockReplacement({
+      replaceStart,
+      replaceEnd,
+      replacementText,
+      cursorAfter,
+      expectedBlockText: blockText,
     });
     if (!hostResult.applied) {
       return null;

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -1795,6 +1795,7 @@ export class SuggestionTextEditService {
       setTimeout(validate, 0);
     }
     setTimeout(validate, 30);
+    setTimeout(validate, 120);
   }
 
   private dispatchInputEvent(elem: SuggestionElement): void {

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -1824,6 +1824,8 @@ export class SuggestionTextEditService {
     }
     setTimeout(validate, 30);
     setTimeout(validate, 120);
+    setTimeout(validate, 250);
+    setTimeout(validate, 500);
   }
 
   private dispatchInputEvent(elem: SuggestionElement): void {

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -593,6 +593,7 @@ export class SuggestionTextEditService {
             replaceEnd,
             replacement,
           );
+    let usedHostEditorForGrammarEdit = false;
     let applyResult:
       | ContentEditableEditResult
       | { didMutateDom: boolean; didDispatchInput: boolean }
@@ -615,6 +616,7 @@ export class SuggestionTextEditService {
           blockText: blockSourceText,
         });
         if (hostEditorSession) {
+          usedHostEditorForGrammarEdit = true;
           const hostResult = hostEditorSession.applyBlockReplacement({
             replaceStart: blockReplaceStart,
             replaceEnd: blockReplaceEnd,
@@ -637,6 +639,9 @@ export class SuggestionTextEditService {
             replacement,
             blockCursorAfter,
           );
+          if (applyResult !== null) {
+            usedHostEditorForGrammarEdit = true;
+          }
         }
         if (applyResult === null) {
           applyResult = this.tryHostGrammarEditWithMatchingBlockText(
@@ -647,6 +652,9 @@ export class SuggestionTextEditService {
             replacement,
             blockCursorAfter,
           );
+          if (applyResult !== null) {
+            usedHostEditorForGrammarEdit = true;
+          }
         }
         if (applyResult === null) {
           // The primary match may fail when getBlockContext returns a
@@ -661,6 +669,9 @@ export class SuggestionTextEditService {
             replacement,
             blockCursorAfter,
           );
+          if (applyResult !== null) {
+            usedHostEditorForGrammarEdit = true;
+          }
         }
       }
     }
@@ -788,7 +799,7 @@ export class SuggestionTextEditService {
       source: "grammar",
       sourceRuleId: edit.sourceRuleId,
     };
-    if (!TextTargetAdapter.isTextValue(entry.elem)) {
+    if (!TextTargetAdapter.isTextValue(entry.elem) && usedHostEditorForGrammarEdit) {
       this.scheduleDeferredContentEditableGrammarValidation(entry, {
         expectedFullText,
         expectedCursorAfter: cursorAfter,

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -1826,6 +1826,8 @@ export class SuggestionTextEditService {
     setTimeout(validate, 120);
     setTimeout(validate, 250);
     setTimeout(validate, 500);
+    setTimeout(validate, 1000);
+    setTimeout(validate, 2000);
   }
 
   private dispatchInputEvent(elem: SuggestionElement): void {

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -629,6 +629,26 @@ export class SuggestionTextEditService {
           }
         }
         if (applyResult === null) {
+          applyResult = this.tryHostGrammarEditWithMissingLeadingRange(
+            entry.elem as HTMLElement,
+            blockSourceText,
+            blockReplaceStart,
+            blockReplaceEnd,
+            replacement,
+            blockCursorAfter,
+          );
+        }
+        if (applyResult === null) {
+          applyResult = this.tryHostGrammarEditWithMatchingBlockText(
+            entry.elem as HTMLElement,
+            blockSourceText,
+            blockReplaceStart,
+            blockReplaceEnd,
+            replacement,
+            blockCursorAfter,
+          );
+        }
+        if (applyResult === null) {
           // The primary match may fail when getBlockContext returns a
           // BR-separated line but the host editor (e.g. CKEditor-5) uses
           // the full paragraph block.  Translate local offsets into the
@@ -1176,6 +1196,97 @@ export class SuggestionTextEditService {
       replaceEnd: fullReplaceEnd,
       replacementText,
       cursorAfter: fullCursorAfter,
+    });
+    if (!hostResult.applied) {
+      return null;
+    }
+    return {
+      didMutateDom: true,
+      didDispatchInput: hostResult.didDispatchInput,
+    };
+  }
+
+  private tryHostGrammarEditWithMatchingBlockText(
+    elem: HTMLElement,
+    blockText: string,
+    replaceStart: number,
+    replaceEnd: number,
+    replacementText: string,
+    cursorAfter: number,
+  ): { didMutateDom: boolean; didDispatchInput: boolean } | null {
+    const session = this.hostEditorAdapterResolver.resolve(elem);
+    if (!session) {
+      return null;
+    }
+    const hostBlockContext = session.getBlockContextAtSelection();
+    if (!hostBlockContext) {
+      return null;
+    }
+    if (
+      this.normalizeComparableBlockText(hostBlockContext.blockText) !==
+      this.normalizeComparableBlockText(blockText)
+    ) {
+      return null;
+    }
+
+    const hostSlice = hostBlockContext.blockText.slice(replaceStart, replaceEnd);
+    const expectedSlice = blockText.slice(replaceStart, replaceEnd);
+    if (this.normalizeComparableBlockText(hostSlice) !== this.normalizeComparableBlockText(expectedSlice)) {
+      return null;
+    }
+
+    const hostResult = session.applyBlockReplacement({
+      replaceStart,
+      replaceEnd,
+      replacementText,
+      cursorAfter,
+    });
+    if (!hostResult.applied) {
+      return null;
+    }
+    return {
+      didMutateDom: true,
+      didDispatchInput: hostResult.didDispatchInput,
+    };
+  }
+
+  private tryHostGrammarEditWithMissingLeadingRange(
+    elem: HTMLElement,
+    blockText: string,
+    replaceStart: number,
+    replaceEnd: number,
+    replacementText: string,
+    cursorAfter: number,
+  ): { didMutateDom: boolean; didDispatchInput: boolean } | null {
+    if (
+      replaceStart !== 0 ||
+      blockText.length < 1
+    ) {
+      return null;
+    }
+
+    const session = this.hostEditorAdapterResolver.resolve(elem);
+    if (!session) {
+      return null;
+    }
+    const hostBlockContext = session.getBlockContextAtSelection();
+    if (!hostBlockContext) {
+      return null;
+    }
+
+    const hostBlockText = this.normalizeComparableBlockText(hostBlockContext.blockText);
+    const expectedTail = this.normalizeComparableBlockText(
+      `${blockText.slice(0, replaceStart)}${blockText.slice(replaceEnd)}`,
+    );
+    if (hostBlockText !== expectedTail) {
+      return null;
+    }
+
+    const hostResult = session.applyBlockReplacement({
+      replaceStart,
+      replaceEnd: replaceStart,
+      replacementText,
+      cursorAfter,
     });
     if (!hostResult.applied) {
       return null;

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -1231,7 +1231,10 @@ export class SuggestionTextEditService {
 
     const hostSlice = hostBlockContext.blockText.slice(replaceStart, replaceEnd);
     const expectedSlice = blockText.slice(replaceStart, replaceEnd);
-    if (this.normalizeComparableBlockText(hostSlice) !== this.normalizeComparableBlockText(expectedSlice)) {
+    if (
+      this.normalizeComparableBlockText(hostSlice) !==
+      this.normalizeComparableBlockText(expectedSlice)
+    ) {
       return null;
     }
 
@@ -1258,10 +1261,7 @@ export class SuggestionTextEditService {
     replacementText: string,
     cursorAfter: number,
   ): { didMutateDom: boolean; didDispatchInput: boolean } | null {
-    if (
-      replaceStart !== 0 ||
-      blockText.length < 1
-    ) {
+    if (replaceStart !== 0 || blockText.length < 1) {
       return null;
     }
 

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -593,7 +593,6 @@ export class SuggestionTextEditService {
             replaceEnd,
             replacement,
           );
-    let usedHostEditorForGrammarEdit = false;
     let applyResult:
       | ContentEditableEditResult
       | { didMutateDom: boolean; didDispatchInput: boolean }
@@ -616,7 +615,6 @@ export class SuggestionTextEditService {
           blockText: blockSourceText,
         });
         if (hostEditorSession) {
-          usedHostEditorForGrammarEdit = true;
           const hostResult = hostEditorSession.applyBlockReplacement({
             replaceStart: blockReplaceStart,
             replaceEnd: blockReplaceEnd,
@@ -631,19 +629,6 @@ export class SuggestionTextEditService {
           }
         }
         if (applyResult === null) {
-          applyResult = this.tryHostGrammarEditWithMissingLeadingRange(
-            entry.elem as HTMLElement,
-            blockSourceText,
-            blockReplaceStart,
-            blockReplaceEnd,
-            replacement,
-            blockCursorAfter,
-          );
-          if (applyResult !== null) {
-            usedHostEditorForGrammarEdit = true;
-          }
-        }
-        if (applyResult === null) {
           applyResult = this.tryHostGrammarEditWithMatchingBlockText(
             entry.elem as HTMLElement,
             blockSourceText,
@@ -652,9 +637,6 @@ export class SuggestionTextEditService {
             replacement,
             blockCursorAfter,
           );
-          if (applyResult !== null) {
-            usedHostEditorForGrammarEdit = true;
-          }
         }
         if (applyResult === null) {
           // The primary match may fail when getBlockContext returns a
@@ -669,13 +651,23 @@ export class SuggestionTextEditService {
             replacement,
             blockCursorAfter,
           );
-          if (applyResult !== null) {
-            usedHostEditorForGrammarEdit = true;
-          }
         }
       }
     }
     if (applyResult === null) {
+      // When every host-editor path above failed, the host's model state
+      // is inconsistent with the DOM view the extension built its edit
+      // from (e.g. Firefox CKEditor-5 hasn't yet synced the character the
+      // user just typed).  In that situation routing the fallback through
+      // beforeinput/execCommand re-enters the host's stale model and
+      // produces a duplicated character.  Force a direct DOM mutation
+      // instead so the host's MutationObserver sees a single clean diff
+      // and reconciles its model in one step.
+      const hostAdapterPresent =
+        !TextTargetAdapter.isTextValue(entry.elem) &&
+        this.hostEditorAdapterResolver.resolve(entry.elem as HTMLElement) !== null;
+      const preferDomMutation =
+        this.shouldPreferDomMutationForGrammar(entry.elem) || hostAdapterPresent;
       applyResult =
         !TextTargetAdapter.isTextValue(entry.elem) &&
         activeBlock !== null &&
@@ -690,7 +682,7 @@ export class SuggestionTextEditService {
               replacement,
               blockCursorAfter,
               {
-                preferDomMutation: this.shouldPreferDomMutationForGrammar(entry.elem),
+                preferDomMutation,
                 scopeRoot: activeBlock,
               },
             )
@@ -701,7 +693,7 @@ export class SuggestionTextEditService {
               replaceEnd,
               replacement,
               cursorAfter,
-              { preferDomMutation: this.shouldPreferDomMutationForGrammar(entry.elem) },
+              { preferDomMutation },
             );
     }
     // For edits with cursorOffset on contenteditable, schedule deferred cursor
@@ -799,15 +791,6 @@ export class SuggestionTextEditService {
       source: "grammar",
       sourceRuleId: edit.sourceRuleId,
     };
-    if (!TextTargetAdapter.isTextValue(entry.elem) && usedHostEditorForGrammarEdit) {
-      this.scheduleDeferredContentEditableGrammarValidation(entry, {
-        expectedFullText,
-        expectedCursorAfter: cursorAfter,
-        expectedBlockText,
-        expectedBlockCursorAfter,
-        originalText,
-      });
-    }
     return {
       applied: true,
       didDispatchInput: finalApplyResult.didDispatchInput,
@@ -1145,20 +1128,6 @@ export class SuggestionTextEditService {
     );
   }
 
-  private isLikelyLateHostGrammarEcho(
-    snapshot: SuggestionSnapshot,
-    expectedFullText: string,
-    expectedCursorAfter: number,
-    originalText: string,
-  ): boolean {
-    if (originalText.length === 0) {
-      return false;
-    }
-    const currentFullText = `${snapshot.beforeCursor}${snapshot.afterCursor}`;
-    const echoedFullText = `${expectedFullText.slice(0, expectedCursorAfter)}${originalText}${expectedFullText.slice(expectedCursorAfter)}`;
-    return currentFullText === echoedFullText;
-  }
-
   /**
    * Fallback for grammar edits when the primary host session match fails.
    *
@@ -1275,50 +1244,6 @@ export class SuggestionTextEditService {
     const hostResult = session.applyBlockReplacement({
       replaceStart,
       replaceEnd,
-      replacementText,
-      cursorAfter,
-    });
-    if (!hostResult.applied) {
-      return null;
-    }
-    return {
-      didMutateDom: true,
-      didDispatchInput: hostResult.didDispatchInput,
-    };
-  }
-
-  private tryHostGrammarEditWithMissingLeadingRange(
-    elem: HTMLElement,
-    blockText: string,
-    replaceStart: number,
-    replaceEnd: number,
-    replacementText: string,
-    cursorAfter: number,
-  ): { didMutateDom: boolean; didDispatchInput: boolean } | null {
-    if (replaceStart !== 0 || blockText.length < 1) {
-      return null;
-    }
-
-    const session = this.hostEditorAdapterResolver.resolve(elem);
-    if (!session) {
-      return null;
-    }
-    const hostBlockContext = session.getBlockContextAtSelection();
-    if (!hostBlockContext) {
-      return null;
-    }
-
-    const hostBlockText = this.normalizeComparableBlockText(hostBlockContext.blockText);
-    const expectedTail = this.normalizeComparableBlockText(
-      `${blockText.slice(0, replaceStart)}${blockText.slice(replaceEnd)}`,
-    );
-    if (hostBlockText !== expectedTail) {
-      return null;
-    }
-
-    const hostResult = session.applyBlockReplacement({
-      replaceStart,
-      replaceEnd: replaceStart,
       replacementText,
       cursorAfter,
     });
@@ -1749,85 +1674,6 @@ export class SuggestionTextEditService {
       applyResult,
       postEditSnapshot: TextTargetAdapter.snapshot(elem as TextTarget),
     };
-  }
-
-  private scheduleDeferredContentEditableGrammarValidation(
-    entry: SuggestionEntry,
-    {
-      expectedFullText,
-      expectedCursorAfter,
-      expectedBlockText,
-      expectedBlockCursorAfter,
-      originalText,
-    }: {
-      expectedFullText: string;
-      expectedCursorAfter: number;
-      expectedBlockText: string | null;
-      expectedBlockCursorAfter: number | null;
-      originalText: string;
-    },
-  ): void {
-    const elem = entry.elem;
-    if (TextTargetAdapter.isTextValue(elem)) {
-      return;
-    }
-
-    let applied = false;
-    const validate = () => {
-      if (applied || !elem.isConnected) {
-        return;
-      }
-      const currentSnapshot = TextTargetAdapter.snapshot(elem as TextTarget);
-      if (
-        this.matchesExpectedGrammarResult(currentSnapshot, expectedFullText, expectedCursorAfter)
-      ) {
-        return;
-      }
-      const shouldRepairMismatch =
-        entry.pendingExtensionEdit?.source === "grammar" ||
-        this.isLikelyLateHostGrammarEcho(
-          currentSnapshot,
-          expectedFullText,
-          expectedCursorAfter,
-          originalText,
-        );
-      if (!shouldRepairMismatch) {
-        return;
-      }
-
-      const corrected = this.correctContentEditableGrammarMismatch(entry, {
-        expectedFullText,
-        expectedCursorAfter,
-        expectedBlockText,
-        expectedBlockCursorAfter,
-      });
-      if (!corrected) {
-        return;
-      }
-
-      applied = true;
-      this.domPreferredGrammarTargets.add(elem as HTMLElement);
-      if (entry.pendingExtensionEdit) {
-        entry.pendingExtensionEdit.cursorAfter = corrected.postEditSnapshot.cursorOffset;
-        entry.pendingExtensionEdit.postEditFingerprint =
-          TextTargetAdapter.createPostEditFingerprint(
-            elem as TextTarget,
-            corrected.postEditSnapshot,
-          );
-      }
-    };
-
-    if (typeof globalThis.requestAnimationFrame === "function") {
-      globalThis.requestAnimationFrame(validate);
-    } else {
-      setTimeout(validate, 0);
-    }
-    setTimeout(validate, 30);
-    setTimeout(validate, 120);
-    setTimeout(validate, 250);
-    setTimeout(validate, 500);
-    setTimeout(validate, 1000);
-    setTimeout(validate, 2000);
   }
 
   private dispatchInputEvent(elem: SuggestionElement): void {

--- a/tests/HostEditorCKEditor5Bridge.test.ts
+++ b/tests/HostEditorCKEditor5Bridge.test.ts
@@ -36,6 +36,9 @@ function createCKEditorMock(initialText: string, initialCursorOffset: number) {
     createRange(start: { offset: number }, end: { offset: number }) {
       return { start, end };
     },
+    createRangeIn() {
+      return { start: { offset: 0 }, end: { offset: text.length } };
+    },
     remove(range: { start: { offset: number }; end: { offset: number } }) {
       text = text.slice(0, range.start.offset) + text.slice(range.end.offset);
     },
@@ -271,6 +274,54 @@ describe("HostEditorMainWorldBridge – CKEditor-5", () => {
 
     expect(response).toEqual({ ok: true, result: { applied: false, didDispatchInput: false } });
     expect(mock.getText()).toBe("hello world");
+  });
+
+  test("rewrites block when host model lags the caller's view (Firefox leading-char lag)", () => {
+    // Simulates Firefox CKEditor-5 where the DOM shows "dThe" (the user
+    // just typed `d`) but the editor model is still "The".  The caller's
+    // view is "dThe" and it wants to replace [0,1] with "D".  The bridge
+    // should detect the lag and rewrite the whole block to "DThe" via
+    // model.change without duplicating the typed character.
+    const mock = createCKEditorMock("The", 0);
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    (editable as HTMLElement & { ckeditorInstance?: unknown }).ckeditorInstance = mock.editor;
+    document.body.appendChild(editable);
+
+    const response = dispatchBridgeRequest(editable, {
+      action: "applyBlockReplacement",
+      replaceStart: 0,
+      replaceEnd: 1,
+      replacementText: "D",
+      cursorAfter: 1,
+      expectedBlockText: "dThe",
+    });
+
+    expect(response).toEqual({ ok: true, result: { applied: true, didDispatchInput: false } });
+    expect(mock.getText()).toBe("DThe");
+    expect(mock.getCursorOffset()).toBe(1);
+  });
+
+  test("rejects stale-model rewrite when host model is not a plausible precursor", () => {
+    // Host model is "xyz" which is not "The" with the replace-range
+    // removed, so the "Firefox leading-char lag" rewrite is not safe.
+    const mock = createCKEditorMock("xyz", 0);
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    (editable as HTMLElement & { ckeditorInstance?: unknown }).ckeditorInstance = mock.editor;
+    document.body.appendChild(editable);
+
+    const response = dispatchBridgeRequest(editable, {
+      action: "applyBlockReplacement",
+      replaceStart: 0,
+      replaceEnd: 1,
+      replacementText: "D",
+      cursorAfter: 1,
+      expectedBlockText: "dThe",
+    });
+
+    expect(response).toEqual({ ok: true, result: { applied: false, didDispatchInput: false } });
+    expect(mock.getText()).toBe("xyz");
   });
 
   test("does not activate for elements without ckeditorInstance", () => {

--- a/tests/HostEditorCKEditor5Bridge.test.ts
+++ b/tests/HostEditorCKEditor5Bridge.test.ts
@@ -69,6 +69,136 @@ function createCKEditorMock(initialText: string, initialCursorOffset: number) {
   };
 }
 
+function createCKEditorMockWithDomSelectionBlocks(
+  initialTexts: [string, string],
+  staleSelection: { blockIndex: 0 | 1; offset: number },
+) {
+  const texts = [...initialTexts];
+  let selectionBlockIndex = staleSelection.blockIndex;
+  let selectionOffset = staleSelection.offset;
+
+  const editable = document.createElement("div");
+  editable.setAttribute("contenteditable", "true");
+  const paragraphs = texts.map((text) => {
+    const paragraph = document.createElement("p");
+    paragraph.appendChild(document.createTextNode(text));
+    editable.appendChild(paragraph);
+    return paragraph;
+  });
+
+  const blocks = texts.map((_text, index) => ({
+    is(type: string) {
+      return type === "element" || type === "paragraph";
+    },
+    getChildren() {
+      return [{ data: texts[index], is: (type: string) => type === "$text" }];
+    },
+  }));
+
+  const writer = {
+    createPositionAt(element: unknown, offset: number) {
+      return { parent: element, offset };
+    },
+    createRange(
+      start: { parent: unknown; offset: number },
+      end: { parent: unknown; offset: number },
+    ) {
+      return { start, end };
+    },
+    remove(range: {
+      start: { parent: unknown; offset: number };
+      end: { parent: unknown; offset: number };
+    }) {
+      const blockIndex = blocks.indexOf(range.start.parent as (typeof blocks)[number]);
+      texts[blockIndex] =
+        texts[blockIndex].slice(0, range.start.offset) + texts[blockIndex].slice(range.end.offset);
+      paragraphs[blockIndex].textContent = texts[blockIndex];
+    },
+    insertText(
+      insertText: string,
+      attrsOrPosition:
+        | { parent: unknown; offset: number }
+        | Record<string, unknown>
+        | null
+        | undefined,
+      maybePosition?: { parent: unknown; offset: number },
+    ) {
+      const position = maybePosition ?? (attrsOrPosition as { parent: unknown; offset: number });
+      const blockIndex = blocks.indexOf(position.parent as (typeof blocks)[number]);
+      texts[blockIndex] =
+        texts[blockIndex].slice(0, position.offset) +
+        insertText +
+        texts[blockIndex].slice(position.offset);
+      paragraphs[blockIndex].textContent = texts[blockIndex];
+    },
+    setSelection(position: { parent: unknown; offset: number }) {
+      selectionBlockIndex = blocks.indexOf(position.parent as (typeof blocks)[number]) as 0 | 1;
+      selectionOffset = position.offset;
+    },
+  };
+
+  const editor = {
+    model: {
+      document: {
+        selection: {
+          getFirstPosition() {
+            return {
+              parent: blocks[selectionBlockIndex],
+              offset: selectionOffset,
+            };
+          },
+        },
+      },
+      change(callback: (w: typeof writer) => void) {
+        callback(writer);
+      },
+    },
+    ui: {
+      view: {
+        editable: {
+          element: editable,
+        },
+      },
+    },
+    editing: {
+      view: {
+        domConverter: {
+          domPositionToView(domParent: Node, domOffset: number) {
+            return { domParent, domOffset };
+          },
+        },
+      },
+      mapper: {
+        toModelPosition(viewPosition: { domParent: Node; domOffset: number }) {
+          const node =
+            viewPosition.domParent.nodeType === Node.TEXT_NODE
+              ? viewPosition.domParent
+              : viewPosition.domParent.childNodes[viewPosition.domOffset] ??
+                viewPosition.domParent.childNodes[viewPosition.domOffset - 1] ??
+                viewPosition.domParent;
+          const paragraph = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as Element);
+          const blockIndex = paragraphs.indexOf(paragraph as HTMLParagraphElement) as 0 | 1;
+          return {
+            parent: blocks[blockIndex],
+            offset:
+              viewPosition.domParent.nodeType === Node.TEXT_NODE
+                ? viewPosition.domOffset
+                : (paragraph?.textContent?.length ?? 0),
+          };
+        },
+      },
+    },
+  };
+
+  return {
+    editor,
+    editable,
+    paragraphs,
+    getTexts: () => [...texts],
+    getSelection: () => ({ blockIndex: selectionBlockIndex, offset: selectionOffset }),
+  };
+}
+
 function dispatchBridgeRequest(
   elem: HTMLElement,
   request: Record<string, unknown>,
@@ -192,6 +322,64 @@ describe("HostEditorMainWorldBridge – CKEditor-5", () => {
     expect(response).toEqual({ ok: true, result: { applied: true, didDispatchInput: false } });
     expect(mock.getText()).toBe("the quick");
     expect(mock.getCursorOffset()).toBe(4);
+  });
+
+  test("returns block context from DOM selection when CKEditor model selection is stale", () => {
+    const mock = createCKEditorMockWithDomSelectionBlocks(["First line", "Second line"], {
+      blockIndex: 0,
+      offset: 0,
+    });
+    (mock.editable as HTMLElement & { ckeditorInstance?: unknown }).ckeditorInstance = mock.editor;
+    document.body.appendChild(mock.editable);
+
+    const secondParagraphText = mock.paragraphs[1].firstChild as Text;
+    const range = document.createRange();
+    range.setStart(secondParagraphText, 6);
+    range.collapse(true);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    const response = dispatchBridgeRequest(mock.editable, { action: "getBlockContext" });
+
+    expect(response).toEqual({
+      ok: true,
+      blockContext: {
+        beforeCursor: "Second",
+        afterCursor: " line",
+        blockText: "Second line",
+      },
+    });
+  });
+
+  test("applies replacement from DOM selection when CKEditor model selection is stale", () => {
+    const mock = createCKEditorMockWithDomSelectionBlocks(["First line", "t"], {
+      blockIndex: 0,
+      offset: 0,
+    });
+    (mock.editable as HTMLElement & { ckeditorInstance?: unknown }).ckeditorInstance = mock.editor;
+    document.body.appendChild(mock.editable);
+
+    const secondParagraphText = mock.paragraphs[1].firstChild as Text;
+    const range = document.createRange();
+    range.setStart(secondParagraphText, 1);
+    range.collapse(true);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    const response = dispatchBridgeRequest(mock.editable, {
+      action: "applyBlockReplacement",
+      replaceStart: 0,
+      replaceEnd: 1,
+      replacementText: "T",
+      cursorAfter: 1,
+      expectedBlockText: "t",
+    });
+
+    expect(response).toEqual({ ok: true, result: { applied: true, didDispatchInput: false } });
+    expect(mock.getTexts()).toEqual(["First line", "T"]);
+    expect(mock.getSelection()).toEqual({ blockIndex: 1, offset: 1 });
   });
 
   test("prefers LineEditorController over CKEditor-5 when both are present", () => {

--- a/tests/HostEditorCKEditor5Bridge.test.ts
+++ b/tests/HostEditorCKEditor5Bridge.test.ts
@@ -173,10 +173,11 @@ function createCKEditorMockWithDomSelectionBlocks(
           const node =
             viewPosition.domParent.nodeType === Node.TEXT_NODE
               ? viewPosition.domParent
-              : viewPosition.domParent.childNodes[viewPosition.domOffset] ??
+              : (viewPosition.domParent.childNodes[viewPosition.domOffset] ??
                 viewPosition.domParent.childNodes[viewPosition.domOffset - 1] ??
-                viewPosition.domParent;
-          const paragraph = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as Element);
+                viewPosition.domParent);
+          const paragraph =
+            node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as Element);
           const blockIndex = paragraphs.indexOf(paragraph as HTMLParagraphElement) as 0 | 1;
           return {
             parent: blocks[blockIndex],

--- a/tests/HostEditorCKEditor5Bridge.test.ts
+++ b/tests/HostEditorCKEditor5Bridge.test.ts
@@ -276,6 +276,70 @@ describe("HostEditorMainWorldBridge – CKEditor-5", () => {
     expect(mock.getText()).toBe("hello world");
   });
 
+  test("flushes pending CKEditor MutationObserver records before reading block context", () => {
+    // Simulates Firefox CKEditor-5 where the DOM shows "dThe" but the
+    // editor's MutationObserver hasn't yet reconciled the typed "d" into
+    // the model.  The bridge must flush the observer (via its public
+    // `flush()` method) so the block context it returns matches the DOM.
+    let modelText = "The";
+    let flushed = false;
+    const block = {
+      is(type: string) {
+        return type === "element" || type === "paragraph";
+      },
+      getChildren() {
+        return [{ data: modelText, is: (type: string) => type === "$text" }];
+      },
+    };
+    const editor = {
+      model: {
+        document: {
+          selection: {
+            getFirstPosition() {
+              return { parent: block, offset: flushed ? 1 : 0 };
+            },
+          },
+        },
+        change() {
+          // not used in this test
+        },
+      },
+      editing: {
+        view: {
+          _observers: new Map<unknown, { flush?: () => void; _mutationObserver?: unknown }>([
+            [
+              {},
+              {
+                _mutationObserver: {},
+                flush() {
+                  // Simulate processing pending records: the typed "d"
+                  // moves from the DOM into the model.
+                  modelText = "dThe";
+                  flushed = true;
+                },
+              },
+            ],
+          ]),
+        },
+      },
+    };
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    (editable as HTMLElement & { ckeditorInstance?: unknown }).ckeditorInstance = editor;
+    document.body.appendChild(editable);
+
+    const response = dispatchBridgeRequest(editable, { action: "getBlockContext" });
+
+    expect(response).toEqual({
+      ok: true,
+      blockContext: {
+        beforeCursor: "d",
+        afterCursor: "The",
+        blockText: "dThe",
+      },
+    });
+  });
+
   test("rewrites block when host model lags the caller's view (Firefox leading-char lag)", () => {
     // Simulates Firefox CKEditor-5 where the DOM shows "dThe" (the user
     // just typed `d`) but the editor model is still "The".  The caller's

--- a/tests/SuggestionTextEditService.test.ts
+++ b/tests/SuggestionTextEditService.test.ts
@@ -2161,6 +2161,144 @@ describe("SuggestionTextEditService", () => {
     expect(entry.pendingExtensionEdit?.replaceStart).toBe(0);
   });
 
+  test("routes grammar edit through host when block text matches but cursor split is stale", () => {
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    Object.defineProperty(editable, "isContentEditable", { value: true, configurable: true });
+    editable.textContent = "dThe";
+    document.body.appendChild(editable);
+    setContentEditableCursor(editable, 1);
+
+    let blockText = "dThe";
+    let beforeCursor = "";
+    let afterCursor = "dThe";
+    let applyCalls = 0;
+    const pageBridge: HostEditorPageBridge = {
+      getBlockContextAtSelection() {
+        return { beforeCursor, afterCursor, blockText };
+      },
+      applyBlockReplacement(_elem, args) {
+        applyCalls += 1;
+        blockText = `${blockText.slice(0, args.replaceStart)}${args.replacementText}${blockText.slice(args.replaceEnd)}`;
+        beforeCursor = blockText.slice(0, args.cursorAfter);
+        afterCursor = blockText.slice(args.cursorAfter);
+        editable.textContent = blockText;
+        setContentEditableCursor(editable, args.cursorAfter);
+        return { applied: true, didDispatchInput: false };
+      },
+    };
+
+    const service = new SuggestionTextEditService({
+      findMentionToken,
+      isSeparator: (value) => /\s/.test(value),
+      hostEditorAdapterResolver: new HostEditorAdapterResolver(pageBridge),
+    });
+    const entry = createSuggestionEntry({ elem: editable });
+
+    const result = service.applyGrammarEdit(
+      entry,
+      {
+        replacement: "D",
+        deleteBackwards: 1,
+        deleteForwards: 0,
+        sourceRuleId: "capitalizeFirstLetter",
+      },
+      {
+        snapshot: {
+          beforeCursor: "d",
+          afterCursor: "The",
+          cursorOffset: 1,
+        },
+        contentEditableContext: {
+          beforeCursor: "d",
+          afterCursor: "The",
+          useFullTextOffsets: false,
+        },
+      },
+    );
+
+    expect(result).toEqual({ applied: true, didDispatchInput: false });
+    expect(applyCalls).toBe(1);
+    expect(editable.textContent).toBe("DThe");
+  });
+
+  test("routes leading-char grammar edit through host when the typed DOM char has not reached the host model yet", () => {
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    Object.defineProperty(editable, "isContentEditable", { value: true, configurable: true });
+    editable.textContent = "dThe";
+    document.body.appendChild(editable);
+    setContentEditableCursor(editable, 1);
+
+    let blockText = "The";
+    let beforeCursor = "T";
+    let afterCursor = "he";
+    let applyCalls = 0;
+    let lastApplyArgs:
+      | {
+          replaceStart: number;
+          replaceEnd: number;
+          replacementText: string;
+          cursorAfter: number;
+        }
+      | null = null;
+    const pageBridge: HostEditorPageBridge = {
+      getBlockContextAtSelection() {
+        return { beforeCursor, afterCursor, blockText };
+      },
+      applyBlockReplacement(_elem, args) {
+        applyCalls += 1;
+        lastApplyArgs = { ...args };
+        blockText = `${blockText.slice(0, args.replaceStart)}${args.replacementText}${blockText.slice(args.replaceEnd)}`;
+        beforeCursor = blockText.slice(0, args.cursorAfter);
+        afterCursor = blockText.slice(args.cursorAfter);
+        editable.textContent = blockText;
+        setContentEditableCursor(editable, args.cursorAfter);
+        return { applied: true, didDispatchInput: false };
+      },
+    };
+
+    const service = new SuggestionTextEditService({
+      findMentionToken,
+      isSeparator: (value) => /\s/.test(value),
+      hostEditorAdapterResolver: new HostEditorAdapterResolver(pageBridge),
+    });
+    const entry = createSuggestionEntry({ elem: editable });
+
+    const result = service.applyGrammarEdit(
+      entry,
+      {
+        replacement: "D",
+        deleteBackwards: 1,
+        deleteForwards: 0,
+        sourceRuleId: "capitalizeFirstLetter",
+      },
+      {
+        snapshot: {
+          beforeCursor: "d",
+          afterCursor: "The",
+          cursorOffset: 1,
+        },
+        contentEditableContext: {
+          beforeCursor: "d",
+          afterCursor: "The",
+          useFullTextOffsets: false,
+        },
+      },
+    );
+
+    expect(result).toEqual({ applied: true, didDispatchInput: false });
+    expect(applyCalls).toBe(1);
+    expect(lastApplyArgs).toEqual({
+      replaceStart: 0,
+      replaceEnd: 0,
+      replacementText: "D",
+      cursorAfter: 1,
+      expectedBlockText: "The",
+    });
+    expect(editable.textContent).toBe("DThe");
+  });
+
   test("falls back to replaceTextByOffsets for grammar edit when host session is not available", () => {
     const service = new SuggestionTextEditService({
       findMentionToken,

--- a/tests/SuggestionTextEditService.test.ts
+++ b/tests/SuggestionTextEditService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, jest, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { ContentEditableAdapter } from "../src/adapters/chrome/content-script/suggestions/ContentEditableAdapter";
 import { HostEditorAdapterResolver } from "../src/adapters/chrome/content-script/suggestions/HostEditorAdapterResolver";
 import type { HostEditorPageBridge } from "../src/adapters/chrome/content-script/suggestions/HostEditorPageBridge";
@@ -2222,7 +2222,15 @@ describe("SuggestionTextEditService", () => {
     expect(editable.textContent).toBe("DThe");
   });
 
-  test("routes leading-char grammar edit through host when the typed DOM char has not reached the host model yet", () => {
+  test("bypasses host session and uses direct DOM mutation when host block text is stale", () => {
+    // Firefox CKEditor-5 can expose a newly typed character in the DOM before
+    // the host editor's model has observed it.  Historic fallbacks tried to
+    // patch the host model anyway, which raced with the host's pending sync
+    // and duplicated the typed character ("DdThe" instead of "DThe").  Now we
+    // detect that the host adapter is present but its reported state is
+    // stale, and route the fallback through a direct DOM mutation.  The host
+    // editor's MutationObserver then sees a single clean diff and reconciles
+    // its model in one step.
     const editable = document.createElement("div");
     editable.setAttribute("contenteditable", "true");
     Object.defineProperty(editable, "isContentEditable", { value: true, configurable: true });
@@ -2230,28 +2238,14 @@ describe("SuggestionTextEditService", () => {
     document.body.appendChild(editable);
     setContentEditableCursor(editable, 1);
 
-    let blockText = "The";
-    let beforeCursor = "T";
-    let afterCursor = "he";
+    // Host reports stale state: "The" instead of the DOM's "dThe".
     let applyCalls = 0;
-    let lastApplyArgs: {
-      replaceStart: number;
-      replaceEnd: number;
-      replacementText: string;
-      cursorAfter: number;
-    } | null = null;
     const pageBridge: HostEditorPageBridge = {
       getBlockContextAtSelection() {
-        return { beforeCursor, afterCursor, blockText };
+        return { beforeCursor: "", afterCursor: "The", blockText: "The" };
       },
-      applyBlockReplacement(_elem, args) {
+      applyBlockReplacement() {
         applyCalls += 1;
-        lastApplyArgs = { ...args };
-        blockText = `${blockText.slice(0, args.replaceStart)}${args.replacementText}${blockText.slice(args.replaceEnd)}`;
-        beforeCursor = blockText.slice(0, args.cursorAfter);
-        afterCursor = blockText.slice(args.cursorAfter);
-        editable.textContent = blockText;
-        setContentEditableCursor(editable, args.cursorAfter);
         return { applied: true, didDispatchInput: false };
       },
     };
@@ -2285,163 +2279,11 @@ describe("SuggestionTextEditService", () => {
       },
     );
 
-    expect(result).toEqual({ applied: true, didDispatchInput: false });
-    expect(applyCalls).toBe(1);
-    expect(lastApplyArgs).toEqual({
-      replaceStart: 0,
-      replaceEnd: 0,
-      replacementText: "D",
-      cursorAfter: 1,
-      expectedBlockText: "The",
-    });
+    expect(result.applied).toBe(true);
+    // Never routed through the stale host model – the host mutation would
+    // race with the host's pending sync and duplicate the typed char.
+    expect(applyCalls).toBe(0);
     expect(editable.textContent).toBe("DThe");
-  });
-
-  test("does not reapply deferred grammar correction for plain contenteditable after further user input", () => {
-    jest.useFakeTimers();
-    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
-    (
-      globalThis as typeof globalThis & {
-        requestAnimationFrame?: typeof requestAnimationFrame;
-      }
-    ).requestAnimationFrame = undefined;
-
-    try {
-      const service = new SuggestionTextEditService({
-        findMentionToken,
-        isSeparator: (value) => /\s/.test(value),
-      });
-
-      const editable = document.createElement("div");
-      editable.setAttribute("contenteditable", "true");
-      Object.defineProperty(editable, "isContentEditable", { value: true, configurable: true });
-      editable.textContent = "dThe";
-      document.body.appendChild(editable);
-      setContentEditableCursor(editable, 1);
-      const entry = createSuggestionEntry({ elem: editable });
-
-      const result = service.applyGrammarEdit(
-        entry,
-        {
-          replacement: "D",
-          deleteBackwards: 1,
-          deleteForwards: 0,
-          sourceRuleId: "capitalizeFirstLetter",
-        },
-        {
-          snapshot: {
-            beforeCursor: "d",
-            afterCursor: "The",
-            cursorOffset: 1,
-          },
-          contentEditableContext: {
-            beforeCursor: "d",
-            afterCursor: "The",
-            useFullTextOffsets: false,
-          },
-        },
-      );
-
-      expect(result).toEqual({ applied: true, didDispatchInput: true });
-      expect(editable.textContent).toBe("DThe");
-
-      editable.textContent = "DThex";
-      setContentEditableCursor(editable, 5);
-      jest.advanceTimersByTime(31);
-
-      expect(editable.textContent).toBe("DThex");
-    } finally {
-      (
-        globalThis as typeof globalThis & {
-          requestAnimationFrame?: typeof requestAnimationFrame;
-        }
-      ).requestAnimationFrame = originalRequestAnimationFrame;
-      jest.useRealTimers();
-    }
-  });
-
-  test("reapplies deferred grammar correction for host editor after late DOM echo", () => {
-    jest.useFakeTimers();
-    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
-    (
-      globalThis as typeof globalThis & {
-        requestAnimationFrame?: typeof requestAnimationFrame;
-      }
-    ).requestAnimationFrame = undefined;
-
-    try {
-      const editable = document.createElement("div");
-      editable.setAttribute("contenteditable", "true");
-      Object.defineProperty(editable, "isContentEditable", { value: true, configurable: true });
-      editable.textContent = "dThe";
-      document.body.appendChild(editable);
-      setContentEditableCursor(editable, 1);
-
-      let blockText = "dThe";
-      let beforeCursor = "d";
-      let afterCursor = "The";
-      const pageBridge: HostEditorPageBridge = {
-        getBlockContextAtSelection() {
-          return { beforeCursor, afterCursor, blockText };
-        },
-        applyBlockReplacement(_elem, args) {
-          blockText = `${blockText.slice(0, args.replaceStart)}${args.replacementText}${blockText.slice(args.replaceEnd)}`;
-          beforeCursor = blockText.slice(0, args.cursorAfter);
-          afterCursor = blockText.slice(args.cursorAfter);
-          editable.textContent = blockText;
-          setContentEditableCursor(editable, args.cursorAfter);
-          return { applied: true, didDispatchInput: false };
-        },
-      };
-
-      const service = new SuggestionTextEditService({
-        findMentionToken,
-        isSeparator: (value) => /\s/.test(value),
-        hostEditorAdapterResolver: new HostEditorAdapterResolver(pageBridge),
-      });
-      const entry = createSuggestionEntry({ elem: editable });
-
-      const result = service.applyGrammarEdit(
-        entry,
-        {
-          replacement: "D",
-          deleteBackwards: 1,
-          deleteForwards: 0,
-          sourceRuleId: "capitalizeFirstLetter",
-        },
-        {
-          snapshot: {
-            beforeCursor: "d",
-            afterCursor: "The",
-            cursorOffset: 1,
-          },
-          contentEditableContext: {
-            beforeCursor: "d",
-            afterCursor: "The",
-            useFullTextOffsets: false,
-          },
-        },
-      );
-
-      expect(result).toEqual({ applied: true, didDispatchInput: false });
-      expect(editable.textContent).toBe("DThe");
-
-      entry.pendingExtensionEdit = null;
-      setTimeout(() => {
-        editable.textContent = "DdThe";
-        setContentEditableCursor(editable, 2);
-      }, 1500);
-      jest.advanceTimersByTime(2200);
-
-      expect(editable.textContent).toBe("DThe");
-    } finally {
-      (
-        globalThis as typeof globalThis & {
-          requestAnimationFrame?: typeof requestAnimationFrame;
-        }
-      ).requestAnimationFrame = originalRequestAnimationFrame;
-      jest.useRealTimers();
-    }
   });
 
   test("falls back to replaceTextByOffsets for grammar edit when host session is not available", () => {

--- a/tests/SuggestionTextEditService.test.ts
+++ b/tests/SuggestionTextEditService.test.ts
@@ -2426,6 +2426,7 @@ describe("SuggestionTextEditService", () => {
       expect(result).toEqual({ applied: true, didDispatchInput: false });
       expect(editable.textContent).toBe("DThe");
 
+      entry.pendingExtensionEdit = null;
       setTimeout(() => {
         editable.textContent = "DdThe";
         setContentEditableCursor(editable, 2);

--- a/tests/SuggestionTextEditService.test.ts
+++ b/tests/SuggestionTextEditService.test.ts
@@ -2222,15 +2222,15 @@ describe("SuggestionTextEditService", () => {
     expect(editable.textContent).toBe("DThe");
   });
 
-  test("bypasses host session and uses direct DOM mutation when host block text is stale", () => {
-    // Firefox CKEditor-5 can expose a newly typed character in the DOM before
-    // the host editor's model has observed it.  Historic fallbacks tried to
-    // patch the host model anyway, which raced with the host's pending sync
-    // and duplicated the typed character ("DdThe" instead of "DThe").  Now we
-    // detect that the host adapter is present but its reported state is
-    // stale, and route the fallback through a direct DOM mutation.  The host
-    // editor's MutationObserver then sees a single clean diff and reconciles
-    // its model in one step.
+  test("routes grammar edit through host bridge with caller's block text when host model is stale", () => {
+    // Firefox CKEditor-5 can expose a newly typed character in the DOM
+    // before its model observes it.  Historic fallbacks tried to patch the
+    // host through beforeinput or a targeted model insertion and then
+    // "repair" the aftermath, which raced with the host's pending sync and
+    // duplicated the typed character.  We now forward the caller's view
+    // ("dThe") as expectedBlockText and let the bridge decide how to apply
+    // – for CKEditor-5 a stale model triggers a full block rewrite through
+    // the editor's own model API, which reconciles in one step.
     const editable = document.createElement("div");
     editable.setAttribute("contenteditable", "true");
     Object.defineProperty(editable, "isContentEditable", { value: true, configurable: true });
@@ -2238,14 +2238,35 @@ describe("SuggestionTextEditService", () => {
     document.body.appendChild(editable);
     setContentEditableCursor(editable, 1);
 
-    // Host reports stale state: "The" instead of the DOM's "dThe".
-    let applyCalls = 0;
+    // Host initially reports stale state: "The" instead of the DOM's "dThe".
+    let blockText = "The";
+    let beforeCursor = "";
+    let afterCursor = "The";
+    const applyCalls: Array<{
+      replaceStart: number;
+      replaceEnd: number;
+      replacementText: string;
+      cursorAfter: number;
+      expectedBlockText: string;
+    }> = [];
     const pageBridge: HostEditorPageBridge = {
       getBlockContextAtSelection() {
-        return { beforeCursor: "", afterCursor: "The", blockText: "The" };
+        return { beforeCursor, afterCursor, blockText };
       },
-      applyBlockReplacement() {
-        applyCalls += 1;
+      applyBlockReplacement(_elem, args) {
+        applyCalls.push({ ...args });
+        // Simulate the bridge's full-block rewrite when the caller's view
+        // diverges from the host model.  Post-edit block text:
+        //   expectedBlockText[0..replaceStart] + replacementText +
+        //   expectedBlockText[replaceEnd..]
+        blockText =
+          args.expectedBlockText.slice(0, args.replaceStart) +
+          args.replacementText +
+          args.expectedBlockText.slice(args.replaceEnd);
+        beforeCursor = blockText.slice(0, args.cursorAfter);
+        afterCursor = blockText.slice(args.cursorAfter);
+        editable.textContent = blockText;
+        setContentEditableCursor(editable, args.cursorAfter);
         return { applied: true, didDispatchInput: false };
       },
     };
@@ -2280,9 +2301,17 @@ describe("SuggestionTextEditService", () => {
     );
 
     expect(result.applied).toBe(true);
-    // Never routed through the stale host model – the host mutation would
-    // race with the host's pending sync and duplicate the typed char.
-    expect(applyCalls).toBe(0);
+    // Exactly one host call, with the caller's view of the block text
+    // attached so the bridge can rewrite through CKEditor's own model
+    // API rather than racing the pending DOM sync.
+    expect(applyCalls).toHaveLength(1);
+    expect(applyCalls[0]).toEqual({
+      replaceStart: 0,
+      replaceEnd: 1,
+      replacementText: "D",
+      cursorAfter: 1,
+      expectedBlockText: "dThe",
+    });
     expect(editable.textContent).toBe("DThe");
   });
 

--- a/tests/SuggestionTextEditService.test.ts
+++ b/tests/SuggestionTextEditService.test.ts
@@ -2234,14 +2234,12 @@ describe("SuggestionTextEditService", () => {
     let beforeCursor = "T";
     let afterCursor = "he";
     let applyCalls = 0;
-    let lastApplyArgs:
-      | {
-          replaceStart: number;
-          replaceEnd: number;
-          replacementText: string;
-          cursorAfter: number;
-        }
-      | null = null;
+    let lastApplyArgs: {
+      replaceStart: number;
+      replaceEnd: number;
+      replacementText: string;
+      cursorAfter: number;
+    } | null = null;
     const pageBridge: HostEditorPageBridge = {
       getBlockContextAtSelection() {
         return { beforeCursor, afterCursor, blockText };

--- a/tests/SuggestionTextEditService.test.ts
+++ b/tests/SuggestionTextEditService.test.ts
@@ -2426,9 +2426,11 @@ describe("SuggestionTextEditService", () => {
       expect(result).toEqual({ applied: true, didDispatchInput: false });
       expect(editable.textContent).toBe("DThe");
 
-      editable.textContent = "DdThe";
-      setContentEditableCursor(editable, 2);
-      jest.advanceTimersByTime(31);
+      setTimeout(() => {
+        editable.textContent = "DdThe";
+        setContentEditableCursor(editable, 2);
+      }, 75);
+      jest.advanceTimersByTime(130);
 
       expect(editable.textContent).toBe("DThe");
     } finally {

--- a/tests/SuggestionTextEditService.test.ts
+++ b/tests/SuggestionTextEditService.test.ts
@@ -2430,8 +2430,8 @@ describe("SuggestionTextEditService", () => {
       setTimeout(() => {
         editable.textContent = "DdThe";
         setContentEditableCursor(editable, 2);
-      }, 75);
-      jest.advanceTimersByTime(130);
+      }, 350);
+      jest.advanceTimersByTime(550);
 
       expect(editable.textContent).toBe("DThe");
     } finally {

--- a/tests/SuggestionTextEditService.test.ts
+++ b/tests/SuggestionTextEditService.test.ts
@@ -2430,8 +2430,8 @@ describe("SuggestionTextEditService", () => {
       setTimeout(() => {
         editable.textContent = "DdThe";
         setContentEditableCursor(editable, 2);
-      }, 350);
-      jest.advanceTimersByTime(550);
+      }, 1500);
+      jest.advanceTimersByTime(2200);
 
       expect(editable.textContent).toBe("DThe");
     } finally {

--- a/tests/SuggestionTextEditService.test.ts
+++ b/tests/SuggestionTextEditService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, jest, test } from "bun:test";
 import { ContentEditableAdapter } from "../src/adapters/chrome/content-script/suggestions/ContentEditableAdapter";
 import { HostEditorAdapterResolver } from "../src/adapters/chrome/content-script/suggestions/HostEditorAdapterResolver";
 import type { HostEditorPageBridge } from "../src/adapters/chrome/content-script/suggestions/HostEditorPageBridge";
@@ -2295,6 +2295,150 @@ describe("SuggestionTextEditService", () => {
       expectedBlockText: "The",
     });
     expect(editable.textContent).toBe("DThe");
+  });
+
+  test("does not reapply deferred grammar correction for plain contenteditable after further user input", () => {
+    jest.useFakeTimers();
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    (
+      globalThis as typeof globalThis & {
+        requestAnimationFrame?: typeof requestAnimationFrame;
+      }
+    ).requestAnimationFrame = undefined;
+
+    try {
+      const service = new SuggestionTextEditService({
+        findMentionToken,
+        isSeparator: (value) => /\s/.test(value),
+      });
+
+      const editable = document.createElement("div");
+      editable.setAttribute("contenteditable", "true");
+      Object.defineProperty(editable, "isContentEditable", { value: true, configurable: true });
+      editable.textContent = "dThe";
+      document.body.appendChild(editable);
+      setContentEditableCursor(editable, 1);
+      const entry = createSuggestionEntry({ elem: editable });
+
+      const result = service.applyGrammarEdit(
+        entry,
+        {
+          replacement: "D",
+          deleteBackwards: 1,
+          deleteForwards: 0,
+          sourceRuleId: "capitalizeFirstLetter",
+        },
+        {
+          snapshot: {
+            beforeCursor: "d",
+            afterCursor: "The",
+            cursorOffset: 1,
+          },
+          contentEditableContext: {
+            beforeCursor: "d",
+            afterCursor: "The",
+            useFullTextOffsets: false,
+          },
+        },
+      );
+
+      expect(result).toEqual({ applied: true, didDispatchInput: true });
+      expect(editable.textContent).toBe("DThe");
+
+      editable.textContent = "DThex";
+      setContentEditableCursor(editable, 5);
+      jest.advanceTimersByTime(31);
+
+      expect(editable.textContent).toBe("DThex");
+    } finally {
+      (
+        globalThis as typeof globalThis & {
+          requestAnimationFrame?: typeof requestAnimationFrame;
+        }
+      ).requestAnimationFrame = originalRequestAnimationFrame;
+      jest.useRealTimers();
+    }
+  });
+
+  test("reapplies deferred grammar correction for host editor after late DOM echo", () => {
+    jest.useFakeTimers();
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    (
+      globalThis as typeof globalThis & {
+        requestAnimationFrame?: typeof requestAnimationFrame;
+      }
+    ).requestAnimationFrame = undefined;
+
+    try {
+      const editable = document.createElement("div");
+      editable.setAttribute("contenteditable", "true");
+      Object.defineProperty(editable, "isContentEditable", { value: true, configurable: true });
+      editable.textContent = "dThe";
+      document.body.appendChild(editable);
+      setContentEditableCursor(editable, 1);
+
+      let blockText = "dThe";
+      let beforeCursor = "d";
+      let afterCursor = "The";
+      const pageBridge: HostEditorPageBridge = {
+        getBlockContextAtSelection() {
+          return { beforeCursor, afterCursor, blockText };
+        },
+        applyBlockReplacement(_elem, args) {
+          blockText = `${blockText.slice(0, args.replaceStart)}${args.replacementText}${blockText.slice(args.replaceEnd)}`;
+          beforeCursor = blockText.slice(0, args.cursorAfter);
+          afterCursor = blockText.slice(args.cursorAfter);
+          editable.textContent = blockText;
+          setContentEditableCursor(editable, args.cursorAfter);
+          return { applied: true, didDispatchInput: false };
+        },
+      };
+
+      const service = new SuggestionTextEditService({
+        findMentionToken,
+        isSeparator: (value) => /\s/.test(value),
+        hostEditorAdapterResolver: new HostEditorAdapterResolver(pageBridge),
+      });
+      const entry = createSuggestionEntry({ elem: editable });
+
+      const result = service.applyGrammarEdit(
+        entry,
+        {
+          replacement: "D",
+          deleteBackwards: 1,
+          deleteForwards: 0,
+          sourceRuleId: "capitalizeFirstLetter",
+        },
+        {
+          snapshot: {
+            beforeCursor: "d",
+            afterCursor: "The",
+            cursorOffset: 1,
+          },
+          contentEditableContext: {
+            beforeCursor: "d",
+            afterCursor: "The",
+            useFullTextOffsets: false,
+          },
+        },
+      );
+
+      expect(result).toEqual({ applied: true, didDispatchInput: false });
+      expect(editable.textContent).toBe("DThe");
+
+      editable.textContent = "DdThe";
+      setContentEditableCursor(editable, 2);
+      jest.advanceTimersByTime(31);
+
+      expect(editable.textContent).toBe("DThe");
+    } finally {
+      (
+        globalThis as typeof globalThis & {
+          requestAnimationFrame?: typeof requestAnimationFrame;
+        }
+      ).requestAnimationFrame = originalRequestAnimationFrame;
+      jest.useRealTimers();
+    }
   });
 
   test("falls back to replaceTextByOffsets for grammar edit when host session is not available", () => {

--- a/tests/e2e/full.e2e.test.ts
+++ b/tests/e2e/full.e2e.test.ts
@@ -2562,6 +2562,97 @@ describeE2E(`Extension E2E Test [${BROWSER_TYPE}]`, () => {
   );
 
   test(
+    "CKEditor capitalizes at the start of an existing paragraph without touching the previous paragraph",
+    async () => {
+      try {
+        await setSettingAndWait(worker!, KEY_ENABLED_GRAMMAR_RULES, ["capitalizeFirstLetter"]);
+        await setSettingAndWait(worker!, KEY_LANGUAGE, "en_US");
+        await setSettingAndWait(worker!, KEY_MIN_WORD_LENGTH_TO_PREDICT, 1);
+        await setSettingAndWait(worker!, KEY_ENABLED_LANGUAGES, SUPPORTED_PREDICTION_LANGUAGE_KEYS);
+        await applyConfigChange(browser, worker!);
+
+        await gotoTestPage(page, { enableCkEditor: true });
+        await page.bringToFront();
+        await waitForInputReady(page, CKEDITOR_SELECTOR);
+
+        await page.evaluate(() => {
+          const ckEditor = (
+            window as typeof window & {
+              __testCkEditor?: { setData: (data: string) => void };
+            }
+          ).__testCkEditor;
+          if (!ckEditor) {
+            throw new Error("CKEditor test instance not found");
+          }
+          ckEditor.setData("<p>First line</p><p>The</p>");
+        });
+
+        const clickTarget = await page.evaluate(() => {
+          const editable = document.querySelector(".ck-editor__editable");
+          const secondParagraph = editable?.querySelectorAll("p")[1];
+          const textNode = secondParagraph?.firstChild;
+          if (!(textNode instanceof Text)) {
+            throw new Error("CKEditor second paragraph text node missing");
+          }
+          secondParagraph.scrollIntoView({ block: "center", inline: "nearest" });
+          const range = document.createRange();
+          range.setStart(textNode, 0);
+          range.setEnd(textNode, 1);
+          const rect = range.getBoundingClientRect();
+          return {
+            x: rect.left + 1,
+            y: rect.top + rect.height / 2,
+          };
+        });
+
+        await page.mouse.click(clickTarget.x, clickTarget.y);
+        await page.keyboard.type("d");
+
+        try {
+          await page.waitForFunction(
+            () => {
+              const editable = document.querySelector(".ck-editor__editable");
+              if (!editable) {
+                return false;
+              }
+              const paragraphs = Array.from(editable.querySelectorAll("p"));
+              if (paragraphs.length < 2) {
+                return false;
+              }
+              const normalize = (text: string): string =>
+                text.replace(/\u00a0/g, " ").replace(/\u200b/g, "").trim();
+              return (
+                normalize(paragraphs[0]?.textContent ?? "") === "First line" &&
+                normalize(paragraphs[1]?.textContent ?? "") === "DThe"
+              );
+            },
+            { timeout: browserTimeout(1500, 3000) },
+          );
+        } catch {
+          const debugState = await page.evaluate(() => {
+            const editable = document.querySelector(".ck-editor__editable");
+            const paragraphs = editable ? Array.from(editable.querySelectorAll("p")) : [];
+            const normalize = (text: string): string =>
+              text.replace(/\u00a0/g, " ").replace(/\u200b/g, "");
+            return {
+              html: editable?.innerHTML ?? "",
+              textContent: normalize(editable?.textContent ?? ""),
+              paragraphs: paragraphs.map((paragraph) => normalize(paragraph.textContent ?? "")),
+            };
+          });
+          throw new Error(
+            `CKEditor paragraph-start capitalization mismatch: ${JSON.stringify(debugState)}`,
+          );
+        }
+      } finally {
+        await setSettingAndWait(worker!, KEY_ENABLED_GRAMMAR_RULES, []);
+        await applyConfigChange(browser, worker!);
+      }
+    },
+    browserTimeout(30000, 50000),
+  );
+
+  test(
     "Quill preserves block structure and caret-correct insertion on Tab acceptance",
     async () => {
       await setSettingAndWait(worker!, KEY_LANGUAGE, "en_US");

--- a/tests/e2e/full.e2e.test.ts
+++ b/tests/e2e/full.e2e.test.ts
@@ -2620,7 +2620,10 @@ describeE2E(`Extension E2E Test [${BROWSER_TYPE}]`, () => {
                 return false;
               }
               const normalize = (text: string): string =>
-                text.replace(/\u00a0/g, " ").replace(/\u200b/g, "").trim();
+                text
+                  .replace(/\u00a0/g, " ")
+                  .replace(/\u200b/g, "")
+                  .trim();
               return (
                 normalize(paragraphs[0]?.textContent ?? "") === "First line" &&
                 normalize(paragraphs[1]?.textContent ?? "") === "DThe"


### PR DESCRIPTION
## What changed

- hardened CKEditor grammar edits to stay on the host-editor path when CKEditor selection/model state lags behind the DOM in Firefox
- added focused unit coverage for stale block-context and missing-leading-range host fallbacks
- added a CKEditor e2e regression that reproduces typing at the start of an existing paragraph

## Why this changed

Issue #356 was reported as fixed, but Firefox still duplicated the leading character in CKEditor when typing before existing paragraph text.

## Root cause

CKEditor on Firefox could expose the newly typed lowercase character in the DOM before that character existed in CKEditor's model/block context. FluentTyper then saw a stale host block like `The` while the DOM already showed `dThe`, missed the normal host parity check, and fell back to generic contenteditable replacement. That produced a second insertion (`D`) instead of a host-owned capitalization, resulting in `dDThe`.

## Impact

- Firefox CKEditor paragraph-start capitalization now yields `DThe` instead of `dDThe`
- existing Chrome behavior remains covered
- the regression is now locked down by unit and e2e tests

## Validation

- `bun test tests/SuggestionTextEditService.test.ts`
- `bun test tests/HostEditorCKEditor5Bridge.test.ts`
- `bun test tests/HostEditorAdapterResolver.test.ts`
- `bun scripts/run-e2e.ts --suite=full --test-name-pattern='CKEditor grammar/text-edit replacement applies in active second paragraph|CKEditor capitalizes at the start of an existing paragraph without touching the previous paragraph'`
- `bun scripts/run-e2e.ts --suite=full --platform=firefox --test-name-pattern='CKEditor grammar/text-edit replacement applies in active second paragraph|CKEditor capitalizes at the start of an existing paragraph without touching the previous paragraph'`
