### PR TITLE
fix: place auto-close caret synchronously on plain contenteditable

### DIFF
--- a/src/adapters/chrome/content-script/suggestions/ContentEditableAdapter.ts
+++ b/src/adapters/chrome/content-script/suggestions/ContentEditableAdapter.ts
@@ -143,6 +143,12 @@ export class ContentEditableAdapter {
       if (shouldTryNativeReplacement) {
         const nativeReplacementResult = this.tryNativeReplacement(elem, replacementText);
         if (nativeReplacementResult.didMutateDom) {
+          // execCommand leaves the caret at the end of the inserted text. Plain
+          // contenteditable has no async host reconciliation to override us, so
+          // place the caret at the final offset synchronously. This prevents a
+          // race where a fast follow-up keystroke (e.g. auto-close "()" then an
+          // immediate "x") lands before a deferred caret correction runs.
+          this.setCaret(editScope, cursorAfter);
           logger.debug("Contenteditable replacement handled by execCommand fallback", {
             didDispatchInput: nativeReplacementResult.didDispatchInput,
             editorTextLength: (elem.textContent ?? "").length,

--- a/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
+++ b/src/adapters/chrome/content-script/suggestions/SuggestionTextEditService.ts
@@ -706,7 +706,19 @@ export class SuggestionTextEditService {
     // DOM asynchronously via microtask. This means didMutateDom is false at check
     // time even though the edit WILL be applied. The deferred callback validates
     // that the expected text appeared before moving the cursor.
-    if (edit.cursorOffset !== undefined && !TextTargetAdapter.isTextValue(entry.elem)) {
+    //
+    // Plain contenteditable applied via the DOM path ("fallback-dom") already had
+    // its caret placed synchronously at the final offset by the adapter, so skip
+    // the deferred relative move-back there — running it would double-correct the
+    // caret. Only host editors (React via beforeinput, CKEditor via host session)
+    // reconcile asynchronously and still need the deferred reposition.
+    const caretPlacedSynchronously =
+      "appliedBy" in applyResult && applyResult.appliedBy === "fallback-dom";
+    if (
+      edit.cursorOffset !== undefined &&
+      !TextTargetAdapter.isTextValue(entry.elem) &&
+      !caretPlacedSynchronously
+    ) {
       const moveBackCount = replacement.length - edit.cursorOffset;
       if (moveBackCount > 0) {
         const targetElem = entry.elem as HTMLElement;

--- a/tests/e2e/full.e2e.test.ts
+++ b/tests/e2e/full.e2e.test.ts
@@ -6069,6 +6069,11 @@ describeE2E(`Extension E2E Test [${BROWSER_TYPE}]`, () => {
       await typeInInput(page, selector, "hello (");
       await waitForInputContentMatch(page, selector, /^hello \(\)$/, browserTimeout(5000, 9000));
 
+      // Wait for deferred cursor repositioning (rAF + setTimeout in content script).
+      // For contenteditable the caret is moved between the brackets asynchronously,
+      // so typing immediately can race and land "x" after ")" -> "hello ()x".
+      await sleep(200);
+
       // Verify cursor position: typing after auto-close should insert between brackets
       await typeInInput(page, selector, "x");
       await waitForInputContentMatch(page, selector, /^hello \(x\)$/, browserTimeout(5000, 9000));

--- a/tests/e2e/full.e2e.test.ts
+++ b/tests/e2e/full.e2e.test.ts
@@ -6069,12 +6069,9 @@ describeE2E(`Extension E2E Test [${BROWSER_TYPE}]`, () => {
       await typeInInput(page, selector, "hello (");
       await waitForInputContentMatch(page, selector, /^hello \(\)$/, browserTimeout(5000, 9000));
 
-      // Wait for deferred cursor repositioning (rAF + setTimeout in content script).
-      // For contenteditable the caret is moved between the brackets asynchronously,
-      // so typing immediately can race and land "x" after ")" -> "hello ()x".
-      await sleep(200);
-
-      // Verify cursor position: typing after auto-close should insert between brackets
+      // Verify cursor position: typing after auto-close should insert between
+      // brackets. Plain contenteditable repositions the caret synchronously, so
+      // an immediate keystroke must land inside the brackets (no settle needed).
       await typeInInput(page, selector, "x");
       await waitForInputContentMatch(page, selector, /^hello \(x\)$/, browserTimeout(5000, 9000));
 


### PR DESCRIPTION
## Summary
Fixes the intermittent **Tests → E2E Full** failure where `Grammar Rule Engine auto-closes brackets in #test-contenteditable` timed out (`to match /^hello \(x\)$/ after 5000ms`). The flaky test was a symptom of a **real product race**, so this fixes the product rather than just padding the test with a sleep.

## Root cause
After auto-closing a bracket, the caret must move *between* the brackets. For `contenteditable` that was done **only** via a deferred bridge event (`requestAnimationFrame` + `setTimeout(30ms)` → `Selection.modify()` in the main world). That deferral exists because React hosts (Lexical/Slate) reconcile asynchronously and override a synchronously-set caret — but it was applied to **all** contenteditable, including plain ones.

So a fast follow-up keystroke on a plain contenteditable could land **before** the reposition ran → `hello ()x` instead of `hello (x)`. This is a genuine fast-typing / paste glitch for real users (worse under main-thread load), not merely a test artifact; in CI it surfaced as the 5000ms timeout.

Plain `<input>`/`<textarea>` were unaffected (caret set synchronously via `setSelectionRange`), which is why only the contenteditable test flaked.

## Fix
Scoped strictly to the plain-DOM apply path (`appliedBy === "fallback-dom"`):
- **`ContentEditableAdapter`**: the `execCommand` branch returned before `setCaret`, leaving the caret after `)`. Now it places the caret at the final offset **synchronously** (matching the pure-DOM path).
- **`SuggestionTextEditService`**: skip the deferred relative move-back for `fallback-dom` (the caret is already correct; a relative move-back would double-correct it).

Host editors (React via `beforeinput` = `host-beforeinput`; CKEditor via host session = no `appliedBy`) are **untouched** and keep their deferred repositioning. `autoBracketClose` is the only rule that sets `cursorOffset`, so the blast radius is exactly the auto-close-on-plain-CE case.

The contenteditable e2e test no longer needs a settle delay (the earlier `sleep(200)` is removed; the Lexical test keeps its own, since React stays deferred).

## Verification
- Full e2e suite **chrome**: 64 pass, 0 fail
- Full e2e suite **firefox**: 64 pass, 0 fail
- Previously-flaky `#test-contenteditable` test: **8/8** runs pass (was racy)
- `bun run lint`, `bun run typecheck`, `prettier --check`: all clean

## Test plan
- [x] CI `Tests` workflow green on both browsers
- [x] `E2E Full` stays green across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)