### PR TITLE
Preserve ambiguous ID forms

### DIFF
--- a/src/core/domain/grammar/implementations/EnglishContractionNormalizationRule.ts
+++ b/src/core/domain/grammar/implementations/EnglishContractionNormalizationRule.ts
@@ -10,7 +10,6 @@ const ENGLISH_CONTRACTION_MAP: Record<string, string> = {
   im: "i'm",
   ive: "i've",
   ill: "i'll",
-  id: "i'd",
   dont: "don't",
   cant: "can't",
   wont: "won't",
@@ -28,7 +27,7 @@ const ENGLISH_CONTRACTION_MAP: Record<string, string> = {
   wouldnt: "wouldn't",
   mustnt: "mustn't",
 };
-const FORCE_PRONOUN_I_PREFIX = new Set(["im", "ive", "ill", "id"]);
+const FORCE_PRONOUN_I_PREFIX = new Set(["im", "ive", "ill"]);
 
 export class EnglishContractionNormalizationRule implements GrammarRule {
   readonly id = "englishContractionNormalization" as const;

--- a/tests/e2e/coverage-matrix.json
+++ b/tests/e2e/coverage-matrix.json
@@ -921,7 +921,7 @@
     },
     {
       "id": "grammar_english_contractions",
-      "description": "English-only grammar rule normalizes common contractions with case preservation.",
+      "description": "English-only grammar rule normalizes common contractions with case preservation while leaving ambiguous id forms unchanged.",
       "coverage": [
         {
           "layer": "e2e-full",
@@ -932,6 +932,11 @@
           "layer": "unit",
           "file": "tests/grammar/V2EnglishRules.test.ts",
           "test": "normalizes contraction forms and preserves case"
+        },
+        {
+          "layer": "unit",
+          "file": "tests/grammar/V2EnglishRules.test.ts",
+          "test": "preserves ambiguous id forms"
         }
       ]
     },

--- a/tests/e2e/full.e2e.test.ts
+++ b/tests/e2e/full.e2e.test.ts
@@ -5640,6 +5640,10 @@ describeE2E(`Extension E2E Test [${BROWSER_TYPE}]`, () => {
       await waitForInputContentEqual(page, selector, "I'm ready", browserTimeout(5000, 9000));
 
       await clearInputContent(page, selector);
+      await typeInInput(page, selector, "ID ");
+      await waitForInputContentEqual(page, selector, "ID ", browserTimeout(5000, 9000));
+
+      await clearInputContent(page, selector);
       await typeInInput(page, selector, "teh ");
       await waitForInputContentEqual(page, selector, "the ", browserTimeout(5000, 9000));
       await typeInInput(page, selector, "cat");

--- a/tests/grammar/V2EnglishRules.test.ts
+++ b/tests/grammar/V2EnglishRules.test.ts
@@ -102,6 +102,14 @@ describe("V2 english grammar rules", () => {
       });
     });
 
+    test("preserves ambiguous id forms", () => {
+      const rule = new EnglishContractionNormalizationRule();
+
+      expect(rule.apply(context("ID ", { lang: "en_US", inputAction: "insert" }))).toBeNull();
+      expect(rule.apply(context("Id ", { lang: "en_US", inputAction: "insert" }))).toBeNull();
+      expect(rule.apply(context("id ", { lang: "en_US", inputAction: "insert" }))).toBeNull();
+    });
+
     test("does not normalize on delete action or non-English context", () => {
       const rule = new EnglishContractionNormalizationRule();
       expect(rule.apply(context("im ", { lang: "en_US", inputAction: "delete" }))).toBeNull();


### PR DESCRIPTION
## Summary

- preserve `ID`, `Id`, and `id` exactly as typed
- remove the ambiguous `id` → `i'd` contraction mapping while keeping unambiguous contraction normalization
- add unit and browser-level regression coverage and update the E2E coverage matrix

## Root cause

The English contraction rule performed a case-insensitive lookup of `id` and then reapplied the input's case pattern. As a result, the valid initialism `ID` was rewritten to `I'D` by a default-enabled safe rule.

Because all casing forms of `id` are valid and contextually ambiguous, this change preserves them rather than guessing. Explicit `i'd` input is still capitalized to `I'd` by the existing pronoun-capitalization rule.

Follow-up to #365.

## Validation

- `bun run check`
- `bun run test` — 1,562 passed
- `bun run check:e2e:coverage`
- `bun run test:e2e` — Chrome: 26 passed
- `bun run test:e2e --platform=firefox` — 26 passed
- `bun run test:e2e:full` — Chrome: 65 passed, 7 expected skips
- `bun run test:e2e:full --platform=firefox` — 65 passed, 7 expected skips